### PR TITLE
Add LinkedIn post generator skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .env.*
 *.log
 .DS_Store
+.tmp/

--- a/casper/commands/generate-linkedin-post.md
+++ b/casper/commands/generate-linkedin-post.md
@@ -1,0 +1,34 @@
+---
+description: Generate LinkedIn posts from source material in your personal writing style
+---
+
+# LinkedIn Post Generator
+
+Generate LinkedIn posts from shared source material, written in your personal style. Supports auto-pulling from Fireflies.ai, Slack, and Google Drive.
+
+## Instructions
+
+1. Read `${CLAUDE_PLUGIN_ROOT}/skills/linkedin-post-generator/SKILL.md` for the complete workflow
+2. Parse any flags passed with the command (see Flags section below)
+3. Follow the appropriate flow based on flags and whether a style profile exists
+
+## Flags
+
+- `/casper:generate-linkedin-post` — Generate posts (runs style setup on first use)
+- `/casper:generate-linkedin-post --setup` — Create or re-create your personal style profile
+- `/casper:generate-linkedin-post --setup-sources` — Configure Fireflies, Slack, and Drive integrations
+- `/casper:generate-linkedin-post --refresh` — Pull fresh source material from integrations, then generate
+- `/casper:generate-linkedin-post --view-style` — View your current style profile
+- `/casper:generate-linkedin-post --view-sources` — List loaded source material
+- `/casper:generate-linkedin-post --add-source` — Add new source material manually
+
+## Quick Reference
+
+| What | Where |
+|------|-------|
+| Style profile | `~/.config/casper/linkedin-style.md` (local, per-user) |
+| Source config | `~/.config/casper/linkedin-sources.md` (local, per-user) |
+| Source material | `${CLAUDE_PLUGIN_ROOT}/skills/linkedin-post-generator/source-material/` |
+| Prompt template | `${CLAUDE_PLUGIN_ROOT}/skills/linkedin-post-generator/references/prompt-template.md` |
+| Integration details | `${CLAUDE_PLUGIN_ROOT}/skills/linkedin-post-generator/references/source-integrations.md` |
+| Full skill docs | `${CLAUDE_PLUGIN_ROOT}/skills/linkedin-post-generator/SKILL.md` |

--- a/casper/skills/linkedin-post-generator/SKILL.md
+++ b/casper/skills/linkedin-post-generator/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: linkedin-post-generator
+description: >
+  LinkedIn post generation from meeting transcripts, Slack dumps, and other source material,
+  written in the user's personal writing style. Use this skill when: generating LinkedIn posts,
+  creating social content from internal material, ghostwriting LinkedIn content, or when the user
+  mentions LinkedIn, social posts, or content generation from transcripts/notes.
+  Supports personal style profiles stored locally per user.
+  Can auto-pull source material from Fireflies.ai, Slack channels, and Google Drive.
+---
+
+# LinkedIn Post Generator
+
+Generate LinkedIn posts from shared source material, written in each user's personal style.
+
+## How It Works
+
+1. **Personal style profile** — stored locally at `~/.config/casper/linkedin-style.md` (never committed)
+2. **Source config** — stored locally at `~/.config/casper/linkedin-sources.md` (never committed)
+3. **Shared source material** — meeting transcripts, Slack dumps, docs in `source-material/`
+4. **Prompt template** — extraction rules, voice guidelines, few-shot examples in `references/prompt-template.md`
+
+## First Run: Style Setup
+
+Check if `~/.config/casper/linkedin-style.md` exists.
+
+**If it does NOT exist**, run the style setup flow:
+
+1. Say: "Welcome to the LinkedIn Post Generator! Before we start, I need to understand your writing style."
+2. Say: "Share 3 LinkedIn posts that match the style you want. You can either paste the post links (e.g. `https://linkedin.com/posts/...`) or paste the text directly."
+3. Wait for the user to provide 3 posts
+4. **If the user provides LinkedIn URLs**, fetch the post content using the apify-scrapers skill:
+   ```bash
+   python ${CLAUDE_PLUGIN_ROOT}/skills/apify-scrapers/scripts/scrape_linkedin_posts.py search "{url}" --max-posts 1
+   ```
+   Extract the post text from the JSON output. If a URL fails to fetch, ask the user to paste that post's text instead.
+5. Analyze the posts for: tone, sentence length, vocabulary, formatting habits, hook style, CTA style, use of questions, paragraph length, overall energy
+6. Create `~/.config/casper/` directory if it doesn't exist
+7. Save the analysis to `~/.config/casper/linkedin-style.md` using this format:
+
+```markdown
+# LinkedIn Style Profile
+Generated: [date]
+
+## Tone
+[analysis]
+
+## Structure Patterns
+[paragraph length, line breaks, formatting habits]
+
+## Hook Style
+[how they open posts]
+
+## CTA / Closing Style
+[how they end posts — questions, challenges, etc.]
+
+## Vocabulary & Phrases
+[distinctive phrases, word choices, energy level]
+
+## Sample Posts
+[the 3 original posts, for reference]
+```
+
+8. Confirm: "Got it! Your style profile is saved. You can update it anytime with `/casper:generate-linkedin-post --setup`"
+
+## First Run: Source Material Check
+
+After style setup completes (or if style exists but source-material/ is empty), check for source material:
+
+1. Check if `source-material/` contains any `.md` files besides `README.md`
+2. **If empty**, guide the user:
+   - Say: "You don't have any source material yet. I need content to generate posts from — meeting transcripts, notes, Slack conversations, etc."
+   - Present options:
+     - **"Connect integrations"** — run the `--setup-sources` flow to configure Fireflies, Slack, or Google Drive auto-pulling
+     - **"Paste something manually"** — run the `--add-source` flow to let the user paste a transcript, notes, or other content
+   - Wait for user choice and proceed with the selected flow
+3. **If source material exists**, proceed with generation
+
+## Normal Run: Post Generation
+
+**If style config exists and source material is available**, proceed with generation:
+
+1. Read `~/.config/casper/linkedin-style.md`
+2. Read ALL files in `${CLAUDE_PLUGIN_ROOT}/skills/linkedin-post-generator/source-material/` (excluding README.md)
+3. Read `${CLAUDE_PLUGIN_ROOT}/skills/linkedin-post-generator/references/prompt-template.md`
+4. Apply the confidentiality rules from the prompt template (no financials, no client names, no pipeline, no team member names)
+5. Generate 2-4 post options based on the source material, written in the user's personal style
+6. Present them in a clean, copy-paste-ready format
+
+## Flags
+
+| Flag | Behavior |
+|------|----------|
+| (none) | Normal generation flow |
+| `--setup` | Re-run style setup, overwrite existing config |
+| `--setup-sources` | Configure which Fireflies, Slack, and Drive sources to pull from |
+| `--refresh` | Pull fresh source material from configured integrations, then generate |
+| `--view-style` | Read and display `~/.config/casper/linkedin-style.md` |
+| `--view-sources` | List and summarize all files in `source-material/` |
+| `--add-source` | Prompt user to paste new content, save as new `.md` file in `source-material/` |
+
+## Flag Details
+
+### `--setup-sources`
+
+Interactive setup for automatic source pulling. Read `references/source-integrations.md` for full details.
+
+1. Ask: "What's your work email address? This is used to filter transcripts to only meetings you attended."
+   - Save as `user_email` in the config
+2. Ask: "Which sources do you want to connect?" Present options:
+   - **Fireflies.ai** — pulls meeting transcripts (needs `FIREFLIES_API_KEY` env var)
+   - **Slack** — pulls messages from channels (needs `SLACK_BOT_TOKEN` env var)
+   - **Google Drive** — pulls docs and transcripts (needs OAuth setup via google-workspace skill)
+3. For each selected source, check if the required env var / credentials exist. If missing, provide setup instructions:
+   - **Fireflies**: "Set `FIREFLIES_API_KEY` in your environment. Get your API key from https://app.fireflies.ai/api"
+   - **Slack**: "Set `SLACK_BOT_TOKEN` in your environment. Create a Slack app at https://api.slack.com/apps"
+   - **Google Drive**: "Run the google-workspace skill setup to configure OAuth."
+4. For each enabled source, gather configuration:
+   - **Fireflies**: search terms (or leave empty for all recent) and days_back
+   - **Slack**: which channels to pull from — list available channels if possible, otherwise ask the user
+   - **Google Drive**: search terms, days_back
+5. Save to `~/.config/casper/linkedin-sources.md`
+6. Confirm: "Source config saved. Run `/casper:generate-linkedin-post --refresh` to pull fresh content."
+
+### `--refresh`
+
+Pull fresh source material from all configured integrations before generating posts. Read `references/source-integrations.md` for the full integration workflow.
+
+**Summary of the flow:**
+
+1. Read `~/.config/casper/linkedin-sources.md` — if missing, run `--setup-sources` first
+2. For each enabled source, call the existing Casper skill scripts:
+   - **Fireflies**: `python ${CLAUDE_PLUGIN_ROOT}/skills/transcript-search/scripts/fireflies_transcript_search.py "{term}" --days-back {N} --content --json`
+     - After fetching, filter results to only transcripts where `user_email` (from source config) appears in the transcript's `participants` array
+   - **Slack**: `python ${CLAUDE_PLUGIN_ROOT}/skills/slack-automation/scripts/slack_search.py read "{channel}" --days {N}`
+   - **Google Drive**: `python ${CLAUDE_PLUGIN_ROOT}/skills/google-workspace/scripts/gdrive_search.py files "{term}" --modified-days {N} --json`
+3. Convert JSON output to clean markdown and save to `source-material/`:
+   - Fireflies: `fireflies-{YYYY-MM-DD}-{title-slug}.md`
+   - Slack: `slack-{channel}-{YYYY-MM-DD}.md`
+   - Google Drive: `gdrive-{title-slug}-{YYYY-MM-DD}.md`
+4. Proceed with normal generation
+
+### `--view-style`
+
+Read `~/.config/casper/linkedin-style.md` and display it. If it doesn't exist, say "No style profile found. Run `/casper:generate-linkedin-post --setup` to create one."
+
+### `--view-sources`
+
+List all `.md` files in `${CLAUDE_PLUGIN_ROOT}/skills/linkedin-post-generator/source-material/` (excluding `README.md`). For each file, show the filename and a 1-line summary of its contents.
+
+### `--add-source`
+
+1. Ask: "Paste the content you want to add as source material (meeting transcript, Slack dump, notes, etc.)"
+2. Ask: "What should I name this source file? (e.g., `team-standup-jan-2025`)"
+3. Save as `${CLAUDE_PLUGIN_ROOT}/skills/linkedin-post-generator/source-material/[name].md`
+4. Confirm: "Source material saved. It will be included in future post generation."
+
+## Reference Files
+
+| File | When to Read |
+|------|-------------|
+| `references/prompt-template.md` | Every generation run — contains voice rules, few-shot examples, confidentiality rules |
+| `references/source-integrations.md` | When running `--refresh` or `--setup-sources` — contains script paths, arguments, output conversion |
+| `references/style-setup.md` | When running `--setup` — contains analysis framework for style profiling |
+| `source-material/*.md` | Every generation run — raw content to extract post ideas from |

--- a/casper/skills/linkedin-post-generator/references/prompt-template.md
+++ b/casper/skills/linkedin-post-generator/references/prompt-template.md
@@ -1,0 +1,109 @@
+# LinkedIn Ghostwriting Prompt Template
+
+## Role
+
+LinkedIn ghostwriter. Adapt to the user's personal style profile at `~/.config/casper/linkedin-style.md` — that file defines tone, structure, hooks, and vocabulary. The rules below are defaults; the user's style profile overrides them when they conflict.
+
+## Voice & Style Rules
+
+- Conversational, direct, zero fluff
+- Short paragraphs, many just one sentence, aggressive line breaks
+- Hook in first 1-2 lines (curiosity or mild controversy — this is what shows before "see more")
+- No hashtags, no emojis, no LinkedIn-speak ("I'm humbled", "excited to announce", "here's the thing")
+- Use concrete details: tool names, time saved, team dynamics (but NEVER financials or client names)
+- End with a question or provocative statement that invites comments
+- Confident but not arrogant
+- Builder's perspective — in the trenches, not commenting from the sidelines
+
+## Structure Pattern
+
+1. **Hook** (1-2 lines) — surprising result, counterintuitive take, or specific scenario
+2. **Story/Context** (3-6 lines) — what actually happened, be specific
+3. **Insight/Framework** (3-6 lines) — what this means broadly, connect to a larger shift
+4. **Takeaway/CTA** (1-3 lines) — direct opinion, challenge, or open question
+
+## Few-Shot Examples
+
+### Example 1
+
+> We're using computer vision models for a ~$100M+ healthcare services firm.
+>
+> One of our closest advisors in the space has been sharing feedback on the project. We turned his notes into an MD file that our eng team can query directly in the codebase.
+>
+> Now, anyone on our team can tap into his perspective on any part of the build instantly.
+>
+> We're doing the same thing internally. Oscar, our designer, is distilling how he sees the world into a set of MD files / skills we can call on.
+>
+> So now when I'm building something, I can pull up his MD file and get his design thinking applied to the product.
+>
+> I guess our roles are becoming: automate yourself by turning your expertise into skills and MD files that others on the team can call on.
+>
+> That, I think, turns into the new operating system for organizations.
+>
+> We're living in a weird and wonderful time. WDYT about the approach?
+
+**Why this works:** Concrete client context (anonymized). Shows a specific workflow. Extrapolates to a bigger idea. Ends with open question.
+
+### Example 2
+
+> You automate a workflow with Claude Code at work. Save 20 hours a week.
+>
+> You tell your manager: "Hey, I just freed up 50% of my week."
+>
+> What happens next?
+>
+> Rarely will the reply be: "Oh perfect, you're fired. Please hand over your Claude credentials on your way out."
+>
+> What actually happens? Their eyes light up.
+>
+> Because everyone has a backlog. The backlog is infinite. Especially at big companies, there are things on that backlog from 2023 that people have been pretending don't exist anymore.
+>
+> The real response is: "That's amazing, here are the other 14 things we haven't been able to get to."
+>
+> I was running an AI training yesterday for a team of 20, and this is exactly what I told them when the job loss concern came up.
+>
+> I also shared stories of this playing out on my own team. When a developer tells me they automated part of their workflow with Opus 4.6? My response is "great, here's another client."
+>
+> Now do companies want to pause on new hiring as aggressively? Yes. That's real. A team of 20 doing the work of 100 is the goal. But that doesn't mean the 20 are at risk. The people already in the room become more valuable, not less.
+>
+> This is the dividing line right now…
+>
+> The person who automates their work and takes on more? That's who leaders want around.
+>
+> The person who automates their work and thinks they can coast? That's who gets replaced.
+>
+> If you're in that second bucket, it's time to level yourself up. Don't wait for your company to roll out an AI strategy. Start experimenting now.
+>
+> The best companies using AI right now? They're hiring like crazy. Not in spite of automation but because of it.
+
+**Why this works:** Relatable scenario. Addresses job loss fear. Personal anecdotes. Clear dividing line. Direct challenge ending.
+
+## Content Extraction Rules
+
+When reading source material:
+
+- Find the most interesting insight, not the most comprehensive
+- Pull specific details (tool names, timelines, team dynamics — NOT financials or client names)
+- Find the tension or surprise
+- Ignore boring operational detail
+- Flag multiple post angles if source material is rich
+
+## Source-Specific Guidance
+
+| Source Type | What to Look For |
+|-------------|-----------------|
+| Transcripts | Surprising moments, client problems/solutions, philosophical debates |
+| Slack dumps | "Aha" moments, quick wins, reactions to tools |
+| Docs | Core thesis, data points, frameworks |
+
+## STRICT CONFIDENTIALITY RULES — NON-NEGOTIABLE
+
+These rules override everything else. Violations are not acceptable under any circumstances.
+
+- **NEVER** include revenue, profit, or margin figures
+- **NEVER** include client names, project codenames, or traceable identifiers
+- **NEVER** include deal sizes, AUM, fund sizes, or pipeline details
+- **NEVER** include internal team member names (unless the post is for/by that person)
+- **NEVER** include financial projections or targets
+- **Anonymize everything:** "a large fund", "one of our engineers", "an enterprise client"
+- If source material contains any of the above, **strip them completely**

--- a/casper/skills/linkedin-post-generator/references/source-integrations.md
+++ b/casper/skills/linkedin-post-generator/references/source-integrations.md
@@ -1,0 +1,197 @@
+# Source Integrations
+
+How to auto-pull source material from Fireflies.ai, Slack, and Google Drive using existing Casper skill scripts. No new scripts — orchestrate the ones that already exist.
+
+## Source Config File
+
+Stored at `~/.config/casper/linkedin-sources.md` (user-local, never committed).
+
+### Format
+
+```markdown
+# LinkedIn Source Configuration
+
+## User
+user_email: you@yourcompany.com
+
+## Fireflies
+enabled: true
+days_back: 14
+search_terms: ["internal", "strategy", "product"]
+
+## Slack
+enabled: true
+channels: []
+days_back: 7
+
+## Google Drive
+enabled: true
+search_terms: ["meeting notes", "strategy", "product update"]
+days_back: 30
+
+## Settings
+auto_refresh: false
+```
+
+The `user_email` field is used to filter Fireflies transcripts to only meetings the user attended. Slack channels should be left empty by default — the setup flow will list available channels for the user to choose from.
+
+### Setup Flow (`--setup-sources`)
+
+1. Ask for the user's work email: "What's your work email? This is used to filter transcripts to only meetings you attended."
+   - Save as `user_email` in the config
+2. Check which integrations are available by verifying env vars:
+   - Fireflies: check if `FIREFLIES_API_KEY` is set
+   - Slack: check if `SLACK_BOT_TOKEN` is set
+   - Google Drive: check if OAuth creds exist — check for `mycreds.txt` in the google-workspace skill scripts directory
+3. For **unavailable** integrations, provide setup instructions:
+   - **Fireflies**: "Get your API key from https://app.fireflies.ai/api and set `FIREFLIES_API_KEY` in your environment."
+   - **Slack**: "Create a Slack app at https://api.slack.com/apps and set `SLACK_BOT_TOKEN` in your environment."
+   - **Google Drive**: "Run the google-workspace skill setup first to configure OAuth."
+4. For available integrations, ask the user for configuration:
+   - **Fireflies**: "Any specific search terms for transcripts, or pull all recent ones?"
+   - **Slack**: "Which channels should I pull from?" — run `python ${CLAUDE_PLUGIN_ROOT}/skills/slack-automation/scripts/slack_search.py search "" --limit 20` to list available channels for the user to choose from
+   - **Google Drive**: "Any specific search terms or folders?"
+5. Ask: "How many days back should I search? (default: 14 for Fireflies, 7 for Slack, 30 for Drive)"
+6. Ask: "Want auto-refresh on every run? (If yes, source material refreshes automatically when you generate posts)"
+7. Save config to `~/.config/casper/linkedin-sources.md`
+
+---
+
+## Refresh Flow (`--refresh`)
+
+### Step 1: Read Config
+
+Read `~/.config/casper/linkedin-sources.md`. If missing, run `--setup-sources` first.
+
+### Step 2: Pull from Fireflies
+
+**Script:** `${CLAUDE_PLUGIN_ROOT}/skills/transcript-search/scripts/fireflies_transcript_search.py`
+
+**For each search term in config:**
+
+```bash
+python ${CLAUDE_PLUGIN_ROOT}/skills/transcript-search/scripts/fireflies_transcript_search.py "{search_term}" --days-back {days_back} --content --json --limit 5
+```
+
+**Requires:** `FIREFLIES_API_KEY` environment variable
+
+**Participant Filtering:** After fetching results, filter transcripts to only include meetings the user attended. For each transcript in the response, check if `user_email` (from source config) appears in the transcript's `participants` array (a list of attendee email addresses). Discard transcripts where the user's email is not found in the participants list. This ensures the user only generates posts from meetings they were actually part of.
+
+**Convert output to markdown:**
+
+For each transcript in the **filtered** `transcripts` array:
+
+```markdown
+# {title}
+Date: {date}
+Duration: {duration} minutes
+Speakers: {comma-separated speaker names}
+
+## Summary
+{summary.overview}
+
+## Key Topics
+{summary.keywords as bullet list}
+
+## Action Items
+{summary.action_items as bullet list}
+
+## Transcript
+{for each sentence: "{speaker_name}: {text}"}
+```
+
+**Save as:** `source-material/fireflies-{YYYY-MM-DD}-{title-slugified}.md`
+
+### Step 3: Pull from Slack
+
+**Script:** `${CLAUDE_PLUGIN_ROOT}/skills/slack-automation/scripts/slack_search.py`
+
+**For each channel in config:**
+
+```bash
+python ${CLAUDE_PLUGIN_ROOT}/skills/slack-automation/scripts/slack_search.py read "{channel_name}" --days {days_back} --limit 100
+```
+
+**Requires:** `SLACK_BOT_TOKEN` environment variable
+
+**Convert output to markdown:**
+
+```markdown
+# Slack: #{channel_name}
+Period: last {days_back} days
+Messages: {message_count}
+
+## Messages
+
+{for each message:}
+### {user} — {date}
+{text}
+
+{if thread_replies:}
+> **{reply.user}**: {reply.text}
+```
+
+**Save as:** `source-material/slack-{channel_name}-{YYYY-MM-DD}.md`
+
+### Step 4: Pull from Google Drive
+
+**Script:** `${CLAUDE_PLUGIN_ROOT}/skills/google-workspace/scripts/gdrive_search.py`
+
+**For each search term in config:**
+
+```bash
+python ${CLAUDE_PLUGIN_ROOT}/skills/google-workspace/scripts/gdrive_search.py files "{search_term}" --modified-days {days_back} --limit 10 --json
+```
+
+**Requires:** OAuth credentials (`client_secrets.json`, `mycreds.txt`) in the google-workspace skill scripts directory
+
+**For each result**, if the file is a Google Doc or text file, read its content. For Google Docs, use the Docs API or download as text.
+
+**Convert output to markdown:**
+
+```markdown
+# {title}
+Source: Google Drive
+Modified: {modifiedDate}
+Type: {mimeType}
+
+## Content
+{file content if available, otherwise:}
+[File found but content not directly readable — open at {webViewLink}]
+```
+
+**Save as:** `source-material/gdrive-{title-slugified}-{YYYY-MM-DD}.md`
+
+### Step 5: Clean Up Old Auto-Pulled Files
+
+Before saving new files, remove previous auto-pulled files (files matching `fireflies-*.md`, `slack-*.md`, `gdrive-*.md` patterns in `source-material/`). This prevents stale content from accumulating. Manually added files (no prefix pattern) are left untouched.
+
+### Step 6: Proceed to Generation
+
+After refresh completes, proceed with the normal post generation flow.
+
+---
+
+## Auto-Refresh
+
+If `auto_refresh: true` is set in the source config, every normal run (no flags) should:
+
+1. Check the most recent auto-pulled file in `source-material/` (by filename date)
+2. If the most recent file is older than the shortest `days_back` in the config, run the refresh flow
+3. If recent files exist, skip refresh and proceed with generation
+
+This avoids pulling on every single run while keeping content reasonably fresh.
+
+---
+
+## Error Handling
+
+| Error | What to Do |
+|-------|-----------|
+| Missing env var (`FIREFLIES_API_KEY`, `SLACK_BOT_TOKEN`) | Skip that source, inform user: "Skipping {source} — {ENV_VAR} not found. Set it in your `.env` file." |
+| Script not found | Skip that source, inform user: "Skipping {source} — script not found at expected path. Is the {skill-name} skill installed?" |
+| API error (rate limit, auth failure) | Skip that source, inform user with the error message. Continue with other sources. |
+| No results returned | Skip that source silently — no error, just no new source material from it. |
+| OAuth credentials missing (Google Drive) | Skip Drive, inform user: "Skipping Google Drive — OAuth not configured. Run the google-workspace skill setup first." |
+
+**Never let a single source failure block the entire flow.** Pull what you can, skip what you can't, and generate from whatever source material is available.

--- a/casper/skills/linkedin-post-generator/references/style-setup.md
+++ b/casper/skills/linkedin-post-generator/references/style-setup.md
@@ -1,0 +1,80 @@
+# Style Setup Guide
+
+This document describes the style analysis process for first-time users.
+
+## Storage Location
+
+Personal style profiles are stored at `~/.config/casper/linkedin-style.md` — local to each user's machine, never committed to the repo.
+
+## Analysis Framework
+
+When a user provides 3 sample LinkedIn posts (either as pasted text or fetched from LinkedIn URLs via the apify-scrapers skill), analyze them across these dimensions:
+
+### Tone
+- Formal vs casual spectrum
+- Confident vs tentative
+- Optimistic vs realistic vs contrarian
+- Personal vs professional
+
+### Structure Patterns
+- Average paragraph length (sentences per paragraph)
+- Use of single-sentence paragraphs
+- Line break frequency
+- Use of lists, bullet points, numbered items
+- Overall post length (short/medium/long)
+
+### Hook Style
+- Question-led openings
+- Bold statement openings
+- Story/scenario openings
+- Data/statistic openings
+- Counterintuitive take openings
+
+### CTA / Closing Style
+- Open questions to audience
+- Direct challenges or calls to action
+- Reflective statements
+- Forward-looking predictions
+- No closing (just ends)
+
+### Vocabulary & Phrases
+- Distinctive phrases or verbal tics
+- Jargon level (industry-specific vs plain language)
+- Energy level (high energy vs measured)
+- Use of "I" vs "we" vs "you"
+- Sentence length distribution (short punchy vs flowing)
+
+## Output Format
+
+Save the analysis as:
+
+```markdown
+# LinkedIn Style Profile
+Generated: [YYYY-MM-DD]
+
+## Tone
+[findings]
+
+## Structure Patterns
+[findings]
+
+## Hook Style
+[findings]
+
+## CTA / Closing Style
+[findings]
+
+## Vocabulary & Phrases
+[findings]
+
+## Sample Posts
+
+### Post 1
+[original text]
+
+### Post 2
+[original text]
+
+### Post 3
+[original text]
+```

--- a/casper/skills/linkedin-post-generator/source-material/README.md
+++ b/casper/skills/linkedin-post-generator/source-material/README.md
@@ -1,0 +1,20 @@
+# Source Material
+
+Shared content that ships with the plugin. The LinkedIn Post Generator reads all `.md` files in this directory (except this README) during post generation.
+
+## What goes here
+
+- Meeting transcripts
+- Slack exports / dumps
+- Document summaries or notes
+- Any raw content you want to generate posts from
+
+## Adding source material
+
+**Via command:** Run `/casper:generate-linkedin-post --add-source` and paste content interactively.
+
+**Manually:** Drop `.md` files into this directory. Use descriptive kebab-case filenames (e.g., `team-retro-jan-2025.md`, `client-kickoff-notes.md`).
+
+## Confidentiality
+
+Source material may contain sensitive details — the skill applies strict confidentiality rules during generation and will never surface client names, financials, deal sizes, or team member names in output. That said, avoid committing source material with highly sensitive information to shared repos when possible.


### PR DESCRIPTION
## Summary

- Adds `linkedin-post-generator` skill that generates LinkedIn posts from meeting transcripts, Slack dumps, and other source material in the user's personal writing style
- Style setup supports **LinkedIn post URLs** (fetched via apify-scrapers) or pasted text — no more copy-pasting post content
- Includes auto-pull integrations (Fireflies.ai, Slack, Google Drive) and strict confidentiality filtering
- Adds `/casper:generate-linkedin-post` command with 6 flags: `--setup`, `--setup-sources`, `--refresh`, `--view-style`, `--view-sources`, `--add-source`
- Removes empty legacy `linkedin-post-generator/` directory from repo root
- Updates `.gitignore` to cover `.tmp/` directory

## Test plan

- [ ] Run `/casper:generate-linkedin-post` — should trigger first-run style setup flow
- [ ] Run style setup with LinkedIn URLs — should fetch post content via apify-scrapers
- [ ] Run style setup with pasted text — should work as fallback
- [ ] Run `/casper:generate-linkedin-post --add-source` — should accept pasted content and save to source-material/
- [ ] Run `/casper:generate-linkedin-post` with source material present — should generate 2-4 posts in markdown
- [ ] Run `/casper:generate-linkedin-post --setup-sources` — should walk through Fireflies/Slack/Drive configuration
- [ ] Verify no client names, financials, or sensitive data appear in generated output