### PR TITLE
Add secret scanning for PRs

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,19 @@
+name: Secret Scan
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: TruffleHog Secret Scan
+        uses: trufflesecurity/trufflehog@main
+        with:
+          extra_args: --results=verified,unverified


### PR DESCRIPTION
## Summary
- Adds a TruffleHog GitHub Action that scans for secrets on PRs targeting main
- Reports both verified and unverified findings

## Test plan
- Open a PR into main and confirm the secret scan job runs