### PR TITLE
Fix composio-connect OAuth flow for all apps

### DIFF
--- a/casper/skills/composio-connect/scripts/execute_action.py
+++ b/casper/skills/composio-connect/scripts/execute_action.py
@@ -252,9 +252,10 @@ def connect_app(app_name: str) -> bool:
                 print(f"✓ {app_name} is already connected")
                 return True
 
-        # Initiate connection
+        # Initiate connection via entity (correct SDK method)
         print(f"Connecting to {app_name}...")
-        connection_request = client.connected_accounts.initiate(
+        entity = client.get_entity('default')
+        connection_request = entity.initiate_connection(
             app_name=app_name,
             redirect_url="https://app.composio.dev/redirect"
         )


### PR DESCRIPTION
## Summary
- **Bug:** `--connect <app>` fails for ALL apps with `ConnectedAccounts.initiate() got an unexpected keyword argument 'app_name'`
- **Root cause:** `connect_app()` called `client.connected_accounts.initiate(app_name=...)` but the SDK method signature expects `integration_id`, not `app_name`
- **Fix:** Use `entity.initiate_connection(app_name=...)` which is the correct SDK method that handles integration creation and OAuth URL generation internally

## What changed
One function in `casper/skills/composio-connect/scripts/execute_action.py`:

```python
# Before (broken)
connection_request = client.connected_accounts.initiate(
    app_name=app_name,
    redirect_url="https://app.composio.dev/redirect"
)

# After (fixed)
entity = client.get_entity('default')
connection_request = entity.initiate_connection(
    app_name=app_name,
    redirect_url="https://app.composio.dev/redirect"
)
```

## Test plan
- [x] Tested Notion — OAuth URL generated successfully
- [x] Tested Slack — detected as already connected
- [x] Tested HubSpot — OAuth URL generated successfully
- [x] Tested Linear — OAuth URL generated successfully
- [x] Tested Zoom — OAuth URL generated successfully
- [x] Audited all other SDK calls in the script — no other issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)