### PR TITLE
Remove hardcoded IDs and personal references from skills

### DIFF
--- a/casper/skills/apify-scrapers/scripts/scrape_linkedin_posts.py
+++ b/casper/skills/apify-scrapers/scripts/scrape_linkedin_posts.py
@@ -5,7 +5,7 @@ Scrapes LinkedIn posts by author URL or search query using Apify.
 
 Usage:
     # Scrape posts from a specific profile
-    python execution/scrape_linkedin_posts.py author "https://www.linkedin.com/in/jaysingh10125/"
+    python execution/scrape_linkedin_posts.py author "https://www.linkedin.com/in/example-user/"
 
     # Scrape posts from multiple profiles
     python execution/scrape_linkedin_posts.py author "https://www.linkedin.com/in/user1/" "https://www.linkedin.com/in/user2/"
@@ -14,10 +14,10 @@ Usage:
     python execution/scrape_linkedin_posts.py search "AI agents" "automation tools"
 
     # Customize max posts
-    python execution/scrape_linkedin_posts.py author "https://www.linkedin.com/in/jaysingh10125/" --max-posts 50
+    python execution/scrape_linkedin_posts.py author "https://www.linkedin.com/in/example-user/" --max-posts 50
 
     # Include comments and reactions
-    python execution/scrape_linkedin_posts.py author "https://www.linkedin.com/in/jaysingh10125/" --scrape-comments --scrape-reactions
+    python execution/scrape_linkedin_posts.py author "https://www.linkedin.com/in/example-user/" --scrape-comments --scrape-reactions
 """
 
 import os
@@ -263,7 +263,7 @@ def main():
         epilog="""
 Examples:
   # Scrape from a profile
-  python execution/scrape_linkedin_posts.py author "https://www.linkedin.com/in/jaysingh10125/"
+  python execution/scrape_linkedin_posts.py author "https://www.linkedin.com/in/example-user/"
 
   # Search for posts
   python execution/scrape_linkedin_posts.py search "AI automation" "LLM agents"

--- a/casper/skills/attio-crm/references/api-guide.md
+++ b/casper/skills/attio-crm/references/api-guide.md
@@ -80,13 +80,13 @@ python scripts/attio_api.py list-notes <record_id> --limit 10
 ### URL Parsing
 
 ```bash
-python scripts/attio_api.py parse-url "https://app.attio.com/casperstudios/companies/view/abc-123"
+python scripts/attio_api.py parse-url "https://app.attio.com/yourworkspace/companies/view/abc-123"
 ```
 
 Output:
 ```json
 {
-  "workspace_slug": "casperstudios",
+  "workspace_slug": "yourworkspace",
   "object_type": "companies",
   "record_id": "abc-123"
 }
@@ -311,7 +311,7 @@ python scripts/attio_api.py list-notes "RECORD_ID" --limit 5
 #### URL Parsing
 ```bash
 # Parse Attio URL
-python scripts/attio_api.py parse-url "https://app.attio.com/casperstudios/companies/view/abc-123"
+python scripts/attio_api.py parse-url "https://app.attio.com/yourworkspace/companies/view/abc-123"
 ```
 
 ### Validation

--- a/casper/skills/attio-crm/references/integration.md
+++ b/casper/skills/attio-crm/references/integration.md
@@ -92,9 +92,9 @@ client.create_note(
 When you have an Attio URL, extract the record ID:
 
 ```python
-url = "https://app.attio.com/casperstudios/companies/view/abc-123-def"
+url = "https://app.attio.com/yourworkspace/companies/view/abc-123-def"
 parsed = client.parse_attio_url(url)
-# {'workspace_slug': 'casperstudios', 'object_type': 'companies', 'record_id': 'abc-123-def'}
+# {'workspace_slug': 'yourworkspace', 'object_type': 'companies', 'record_id': 'abc-123-def'}
 
 company = client.get_company(parsed["record_id"])
 ```

--- a/casper/skills/attio-crm/scripts/attio_api.py
+++ b/casper/skills/attio-crm/scripts/attio_api.py
@@ -16,7 +16,7 @@ Usage:
     python execution/attio_api.py create-note e26784a0-0933-45f2-99ea-e432ac41142e "Proposal Generated" "Link: https://docs.google.com/..."
 
     # Extract company ID from Attio URL
-    python execution/attio_api.py parse-url "https://app.attio.com/casperstudios/companies/view/e26784a0-0933-45f2-99ea-e432ac41142e"
+    python execution/attio_api.py parse-url "https://app.attio.com/yourworkspace/companies/view/e26784a0-0933-45f2-99ea-e432ac41142e"
 """
 
 import os

--- a/casper/skills/content-generation/scripts/generate_document.py
+++ b/casper/skills/content-generation/scripts/generate_document.py
@@ -42,7 +42,7 @@ load_dotenv()
 # Configuration
 SETTINGS_FILE = "settings.yaml"
 CREDENTIALS_FILE = "mycreds.txt"
-DEFAULT_TEMPLATE_ID = "1LakD2oCGrTQSeoTDZJhEBD3c2gE_gwNKoG2bAlK8DNs"
+DEFAULT_TEMPLATE_ID = os.environ.get("DOC_TEMPLATE_ID", "")
 
 # =============================================================================
 # BRAND STYLING (Casper Studios)

--- a/casper/skills/content-generation/scripts/generate_flowchart.py
+++ b/casper/skills/content-generation/scripts/generate_flowchart.py
@@ -296,8 +296,8 @@ def _call_openrouter(system_prompt: str, user_prompt: str) -> str:
     headers = {
         "Authorization": f"Bearer {OPENROUTER_API_KEY}",
         "Content-Type": "application/json",
-        "HTTP-Referer": "https://github.com/casper-ai",
-        "X-Title": "Casper AI Flowchart Generator"
+        "HTTP-Referer": "https://github.com/your-org",
+        "X-Title": "Flowchart Generator"
     }
 
     payload = {

--- a/casper/skills/content-generation/scripts/generate_proposal.py
+++ b/casper/skills/content-generation/scripts/generate_proposal.py
@@ -59,7 +59,7 @@ except ImportError:
 # Configuration
 SETTINGS_FILE = "settings.yaml"
 CREDENTIALS_FILE = "mycreds.txt"
-DEFAULT_TEMPLATE_ID = "1LakD2oCGrTQSeoTDZJhEBD3c2gE_gwNKoG2bAlK8DNs"
+DEFAULT_TEMPLATE_ID = os.environ.get("DOC_TEMPLATE_ID", "")
 OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
 
 # =============================================================================

--- a/casper/skills/google-workspace/references/gmail-search.md
+++ b/casper/skills/google-workspace/references/gmail-search.md
@@ -52,7 +52,7 @@ python scripts/gmail_search.py --domain "kit.com" --json
       "thread_id": "thread456",
       "subject": "Re: Proposal Review",
       "from": "John <john@client.com>",
-      "to": "giorgio@casperstudios.com",
+      "to": "user@yourcompany.com",
       "date": "2025-12-25T10:30:00",
       "snippet": "Thanks for sending over..."
     }
@@ -216,7 +216,7 @@ def search_client_mentions(service, client_name, internal_domain, days=14):
     }
 
 # Usage
-results = search_client_mentions(service, "Microsoft", "casperstudios.com", days=14)
+results = search_client_mentions(service, "Microsoft", "yourcompany.com", days=14)
 ```
 
 ### Get Thread with All Messages

--- a/casper/skills/google-workspace/scripts/create_client_folder.py
+++ b/casper/skills/google-workspace/scripts/create_client_folder.py
@@ -40,9 +40,9 @@ SETTINGS_FILE = "settings.yaml"
 CREDENTIALS_FILE = "mycreds.txt"
 CLIENT_SECRETS_FILE = "client_secrets.json"
 
-# Casper Studios Client Projects shared drive
-SHARED_DRIVE_ID = "0APeqlhKR8qTPUk9PVA"
-SHARED_DRIVE_NAME = "[03] Casper Studios - Client Projects"
+# Shared drive configuration (set via env vars or .env)
+SHARED_DRIVE_ID = os.getenv("SHARED_DRIVE_ID", "")
+SHARED_DRIVE_NAME = os.getenv("SHARED_DRIVE_NAME", "Client Projects")
 
 # Standard client folder structure
 CLIENT_FOLDER_STRUCTURE = {

--- a/casper/skills/google-workspace/scripts/gdrive_search.py
+++ b/casper/skills/google-workspace/scripts/gdrive_search.py
@@ -34,8 +34,8 @@ SETTINGS_FILE = "settings.yaml"
 CREDENTIALS_FILE = "mycreds.txt"
 CLIENT_SECRETS_FILE = "client_secrets.json"
 
-# Casper Studios shared drive
-SHARED_DRIVE_ID = "0APeqlhKR8qTPUk9PVA"
+# Shared drive configuration (set via env vars or .env)
+SHARED_DRIVE_ID = os.getenv("SHARED_DRIVE_ID", "")
 
 
 class DriveSearchError(Exception):

--- a/casper/skills/parallel-research/scripts/basic_research.py
+++ b/casper/skills/parallel-research/scripts/basic_research.py
@@ -37,7 +37,7 @@ load_dotenv()
 # Configuration
 PARALLEL_API_KEY = os.getenv("PARALLEL_API_KEY")
 TASK_API_URL = "https://api.parallel.ai/v1/tasks/runs"
-SHARED_DRIVE_ID = "0APeqlhKR8qTPUk9PVA"  # Casper Studios shared drive
+SHARED_DRIVE_ID = os.getenv("SHARED_DRIVE_ID", "")
 
 # Output directory
 OUTPUT_DIR = Path(".tmp/basic_research")

--- a/casper/skills/voice-agents/scripts/create_voice_agent.py
+++ b/casper/skills/voice-agents/scripts/create_voice_agent.py
@@ -37,10 +37,10 @@ load_dotenv()
 # Configuration
 ELEVENLABS_API_KEY = os.getenv("ELEVENLABS_API_KEY")
 OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
-SHARED_DRIVE_ID = "0APeqlhKR8qTPUk9PVA"
+SHARED_DRIVE_ID = os.getenv("SHARED_DRIVE_ID", "")
 
 # ElevenLabs webhook ID for post-call processing
-POST_CALL_WEBHOOK_ID = "b9c2f306ac0a477bafd3dbf922aa2921"
+POST_CALL_WEBHOOK_ID = os.getenv("ELEVENLABS_WEBHOOK_ID", "")
 
 
 class VoiceAgentError(Exception):


### PR DESCRIPTION
## Summary

Removes all hardcoded service IDs and personal identifiers from skill scripts and reference docs, replacing them with environment variables and generic placeholders. Users set their own values via `.env`.

- **No directory renames, no branding changes** — only files under `casper/skills/` are touched
- All scripts maintain identical behavior when env vars are configured
- Default empty strings ensure scripts don't crash without env vars (they'll fail at API call time with a clear error)

## Hardcoded IDs → environment variables

| What | Before (hardcoded) | After (env var) |
|------|-------------------|-----------------|
| Google Drive shared drive | `"0APeqlhKR8qTPUk9PVA"` | `os.getenv("SHARED_DRIVE_ID", "")` |
| Google Drive name | `"[03] Casper Studios - Client Projects"` | `os.getenv("SHARED_DRIVE_NAME", "Client Projects")` |
| Google Docs template | `"1LakD2oCGrTQSeoTDZJhEBD3c2gE_gwNKoG2bAlK8DNs"` | `os.environ.get("DOC_TEMPLATE_ID", "")` |
| ElevenLabs webhook | `"b9c2f306ac0a477bafd3dbf922aa2921"` | `os.getenv("ELEVENLABS_WEBHOOK_ID", "")` |

## Personal references → generic placeholders

| What | Before | After |
|------|--------|-------|
| LinkedIn profile URLs | `jaysingh10125` | `example-user` |
| Attio workspace slug | `casperstudios` | `yourworkspace` |
| Email in examples | `giorgio@casperstudios.com` | `user@yourcompany.com` |
| OpenRouter HTTP headers | `casper-ai` / `Casper AI` | `your-org` / `Flowchart Generator` |

## Files changed (12 files, all under `casper/skills/`)

**Scripts (7):**
- `google-workspace/scripts/create_client_folder.py`
- `google-workspace/scripts/gdrive_search.py`
- `parallel-research/scripts/basic_research.py`
- `voice-agents/scripts/create_voice_agent.py`
- `content-generation/scripts/generate_proposal.py`
- `content-generation/scripts/generate_document.py`
- `content-generation/scripts/generate_flowchart.py`

**Reference docs (3):**
- `attio-crm/references/api-guide.md`
- `attio-crm/references/integration.md`
- `google-workspace/references/gmail-search.md`

**Scripts with example URLs (2):**
- `apify-scrapers/scripts/scrape_linkedin_posts.py`
- `attio-crm/scripts/attio_api.py`

## Setup for users

Add to `.env`:
```bash
SHARED_DRIVE_ID=your-google-drive-id
SHARED_DRIVE_NAME=Your Drive Name
DOC_TEMPLATE_ID=your-google-docs-template-id
ELEVENLABS_WEBHOOK_ID=your-webhook-id
```

## Test plan

- [x] Verified zero hardcoded IDs remain in `casper/skills/` (`grep` for all original IDs returns empty)
- [x] Verified zero personal identifiers remain (`jaysingh`, `casperstudios`, `giorgio@`)
- [x] All changes are env var swaps — function signatures and logic unchanged
- [ ] Reviewer: set env vars and confirm scripts connect to your Drive/ElevenLabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)