### PR TITLE
feat: add extract-my-action-items skill and Slack posting script

### DIFF
--- a/dev-toolkit/skills/extract-my-action-items/scripts/slack-post.mjs
+++ b/dev-toolkit/skills/extract-my-action-items/scripts/slack-post.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * Post action items markdown to Slack as mrkdwn.
+ * Usage: node slack-post.mjs <path-to-action-items.md>
+ * Requires env vars: SLACK_BOT_TOKEN, SLACK_CHANNEL_ID
+ */
+import { readFileSync } from "fs";
+import { execSync } from "child_process";
+
+const file = process.argv[2];
+if (!file) {
+  console.error("Usage: node slack-post.mjs <path-to-action-items.md>");
+  process.exit(1);
+}
+
+const TOKEN = process.env.SLACK_BOT_TOKEN;
+const CHANNEL = process.env.SLACK_CHANNEL_ID;
+if (!TOKEN || !CHANNEL) {
+  console.error("Missing SLACK_BOT_TOKEN or SLACK_CHANNEL_ID");
+  process.exit(1);
+}
+
+const md = readFileSync(file, "utf-8");
+
+// --- Extract header metadata ---
+const dateMatch = md.match(/\*\*Date:\*\* (.+)/);
+const linkMatch = md.match(/\*\*Fireflies Link:\*\* (.+)/);
+const titleMatch = md.match(/^# (.+)/m);
+const date = dateMatch?.[1] ?? "";
+const link = linkMatch?.[1] ?? "";
+const title = titleMatch?.[1] ?? "Action Items";
+const header = `*${title}* | <${link}|Fireflies> | ${date}`;
+
+// --- Strip header block, keep body from first ## onward ---
+const bodyStart = md.indexOf("\n## ");
+const body = bodyStart >= 0 ? md.slice(bodyStart) : md;
+
+// --- Markdown -> Slack mrkdwn line-by-line ---
+function convertLine(line) {
+  if (line.trim() === "---") return "";
+  if (line.startsWith("## ")) return `\n*${line.slice(3).trim()}*`;
+  if (line.startsWith("### ")) return `_${line.slice(4).trim()}_`;
+  if (line.startsWith("# ")) return `*${line.slice(2).trim()}*`;
+
+  line = line.replace(/^- \[ \] \*\*(.+?)\*\*/, "• *$1*");
+  line = line.replace(/^(\d+)\. \*\*(.+?)\*\*/, "$1. *$2*");
+  line = line.replace(/\*\*(.+?)\*\*/g, "*$1*");
+  line = line.replace(/^(\s+)- > "(.+)"/, '$1> _"$2"_');
+  line = line.replace(/^(\s+)- > (.+)/, "$1> _$2_");
+  line = line.replace(/^  - (.+)/, "   $1");
+  line = line.replace(/\[(.+?)\]\((.+?)\)/g, "<$2|$1>");
+  return line;
+}
+
+const converted = body
+  .split("\n")
+  .map(convertLine)
+  .join("\n")
+  .replace(/\n{3,}/g, "\n\n")
+  .trim();
+
+const fullText = `${header}\n\n${converted}`;
+
+// --- Chunk by person sections, max 3900 chars ---
+const sections = fullText.split(/\n\n(?=\n?\*[A-Z])/);
+const MAX = 3900;
+const chunks = [];
+let current = "";
+for (const section of sections) {
+  if (current.length + section.length + 2 > MAX && current.length > 0) {
+    chunks.push(current.trim());
+    current = section;
+  } else {
+    current = current ? current + "\n\n" + section : section;
+  }
+}
+if (current) chunks.push(current.trim());
+
+// --- Post each chunk ---
+console.log(`Posting ${chunks.length} message(s) (${fullText.length} chars total)`);
+for (let i = 0; i < chunks.length; i++) {
+  const payload = JSON.stringify({
+    channel: CHANNEL,
+    text: chunks[i],
+    unfurl_links: false,
+    mrkdwn: true,
+  });
+  try {
+    const resp = execSync(
+      `curl -s -X POST https://slack.com/api/chat.postMessage -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json; charset=utf-8" -d @-`,
+      { input: payload, encoding: "utf-8" }
+    );
+    const result = JSON.parse(resp);
+    if (result.ok) {
+      console.log(`  Message ${i + 1}/${chunks.length}: posted (ts=${result.ts})`);
+    } else {
+      console.log(`  Message ${i + 1}/${chunks.length}: FAILED - ${result.error}`);
+    }
+  } catch (e) {
+    console.error(`  Message ${i + 1}/${chunks.length}: ERROR - ${e.message}`);
+  }
+}

--- a/dev-toolkit/skills/extract-my-action-items/skill.md
+++ b/dev-toolkit/skills/extract-my-action-items/skill.md
@@ -1,0 +1,162 @@
+---
+name: extract-my-action-items
+description: Extract action items from a Fireflies call transcript. Default extracts for ALL attendees; specify a target person to extract only theirs. Use when the user wants to find commitments, assignments, and follow-ups from a recorded meeting.
+user-invocable: true
+---
+
+# Extract Action Items
+
+Extract action items from a Fireflies transcript using parallel subagents. Catches items automated summaries miss.
+
+**Two modes:**
+- **All attendees (default):** No target specified — extract action items for every participant
+- **Single person:** Target specified — extract action items for that person only
+
+## Phase 1: Find and Fetch
+
+1. Search with `mcp__fireflies__fireflies_get_transcripts` (date, or keyword)
+2. Determine mode:
+   - If a target person is specified in the invocation → **single-person mode**
+   - Otherwise → **all-attendees mode**
+3. Fetch `mcp__fireflies__fireflies_get_summary` and `mcp__fireflies__fireflies_get_transcript` in parallel
+
+## Phase 2: Preprocess Transcript
+
+The transcript API returns a JSON array. Extract to plain text before chunking:
+
+```bash
+jq -r '.[].text' < raw_transcript.json > .claude/scratchpad/transcript.txt
+```
+
+If `jq` is unavailable, use Python: `json.load` then join `[e["text"] for e in data]` with newlines.
+
+Count lines: `wc -l < .claude/scratchpad/transcript.txt`
+
+**All-attendees mode:** Also extract the distinct speaker list from the transcript JSON:
+
+```python
+speakers = sorted(set(e["speaker_name"] for e in data if e.get("speaker_name")))
+```
+
+## Phase 3: Parallel Subagent Extraction
+
+**Chunk sizing:** `ceil(total_lines / 5)` lines per chunk, minimum 200. Adjust chunk count so no chunk is under 200 lines.
+
+Launch one `general-purpose` subagent per chunk.
+
+### Single-Person Prompt
+
+```
+Read lines [START] to [END] of [FILE_PATH].
+
+Find ALL action items for [TARGET_PERSON]. Return each as:
+- **Item**: what they committed to
+- **Quote**: exact words from transcript
+- **Context**: who else involved, any deadline
+
+Beyond obvious commitments ("I'll do X"), catch these non-obvious patterns:
+- Self-notes: "I'll make a note to...", "let me jot down..."
+- Admissions implying catch-up: "I dropped the ball on X", "I still haven't read X"
+- Conditional offers that became commitments: "If we have time, I'm happy to..."
+- Volunteering: "I guess I'll volunteer to..."
+- Exploration tasks: "Let me spend a few hours with it"
+- Questions/topics for external parties: "I need to ask [person/firm] about X", "thing to discuss with [party]"
+```
+
+### All-Attendees Prompt
+
+```
+Read lines [START] to [END] of [FILE_PATH].
+
+The meeting attendees are: [SPEAKER_LIST]
+
+Find ALL action items for EVERY attendee. Group by person. For each item return:
+- **Person**: who owns the action item
+- **Item**: what they committed to
+- **Quote**: exact words from transcript
+- **Context**: who else involved, any deadline
+
+Beyond obvious commitments ("I'll do X"), catch these non-obvious patterns:
+- Self-notes: "I'll make a note to...", "let me jot down..."
+- Admissions implying catch-up: "I dropped the ball on X", "I still haven't read X"
+- Conditional offers that became commitments: "If we have time, I'm happy to..."
+- Volunteering: "I guess I'll volunteer to..."
+- Exploration tasks: "Let me spend a few hours with it"
+- Questions/topics for external parties: "I need to ask [person/firm] about X", "thing to discuss with [party]"
+- Delegations: "[Person], can you handle X?", "I'll leave that to [person]"
+```
+
+## Phase 4: Consolidate
+
+Merge subagent results, deduplicate, and categorize. **Only include categories that have items.**
+
+### Categories
+
+1. **High Priority / Technical** — Code changes, bug fixes, PR reviews, investigations
+2. **Pairing / Collaboration** — Scheduled syncs, joint work sessions
+3. **Content / Research** — Reading, writing, experiments, documentation
+4. **Questions for External Parties** — Topics to raise with specific people/firms outside the immediate team
+5. **Exploration / Tooling** — Tool evaluations, setup, environment tasks
+6. **Catch-up** — Things explicitly acknowledged as dropped or missed
+
+### Output
+
+**Single-person mode** — Write to `.claude/scratchpad/[name]-action-items-YYYY-MM-DD.md`:
+
+```markdown
+# [Name] Action Items — [Meeting Title]
+
+**Date:** [Date]
+**Fireflies Link:** https://app.fireflies.ai/view/[TRANSCRIPT_ID]
+
+## [Category Name]
+
+- [ ] **Item title**
+  - Context and details
+  - > "Exact quote"
+
+## Quick Reference — Time-Sensitive
+
+1. [Item with deadline or scheduled time]
+```
+
+**All-attendees mode** — Write to `.claude/scratchpad/action-items-YYYY-MM-DD.md`:
+
+```markdown
+# Action Items — [Meeting Title]
+
+**Date:** [Date]
+**Fireflies Link:** https://app.fireflies.ai/view/[TRANSCRIPT_ID]
+
+## [Person Name]
+
+### [Category Name]
+
+- [ ] **Item title**
+  - Context and details
+  - > "Exact quote"
+
+## Quick Reference — Time-Sensitive
+
+1. [Person] — [Item with deadline or scheduled time]
+```
+
+## Phase 5: Review & Post to Slack
+
+1. Use `AskUserQuestion`: **"Post action items to Slack?"** — options: "Post to Slack", "Skip — just keep the file"
+2. If approved, run the bundled script with the output file path:
+
+```bash
+node [SKILL_DIR]/scripts/slack-post.mjs [OUTPUT_FILE_PATH]
+```
+
+The script handles markdown-to-mrkdwn conversion, chunking by person section (max 3900 chars), and posting via `curl` + Slack API. Requires env vars `SLACK_BOT_TOKEN` and `SLACK_CHANNEL_ID`.
+
+3. After posting (or skipping), delete all artifacts created during the run: `transcript.txt`, the action items markdown file, and any other temp files written to `.claude/scratchpad/` during this workflow.
+
+## Example Invocations
+
+- `/extract-my-action-items` — all attendees, most recent meeting
+- `/extract-my-action-items standup` — all attendees, search for "standup"
+- `/extract-my-action-items for Basti from yesterday` — single person
+- `/extract-my-action-items 01KFY1RSEVVQW7MB1TKG4N2D20` — all attendees, specific transcript


### PR DESCRIPTION
Handy skill I use to extract items that the fireflies' out-of-the-box feature often misses. 
Optional post processing step to post to slack. Searches the `settings.local.json` for a bottoken and channel id which is also handy