### PR TITLE
Add weekly marketplace digest Slack notification

### DIFF
--- a/.github/workflows/weekly-marketplace-digest.yml
+++ b/.github/workflows/weekly-marketplace-digest.yml
@@ -26,22 +26,31 @@ jobs:
           echo "=== Marketplace Weekly Digest ==="
           echo "Looking at changes since: $SINCE"
 
-          # Gather commits from the last 7 days
-          COMMITS=$(git log --since="$SINCE" --pretty=format:"%h %s (%an)" --no-merges 2>/dev/null || true)
-          COMMIT_COUNT=$(echo "$COMMITS" | grep -c . 2>/dev/null || echo "0")
-
           # Find changed files in the last 7 days
           CHANGED_FILES=$(git log --since="$SINCE" --name-only --pretty=format:"" --no-merges 2>/dev/null | sort -u | grep -v '^$' || true)
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No changes in the last 7 days. Skipping Slack notification."
+            exit 0
+          fi
+
+          # Helper: extract the first sentence of the description from a SKILL.md
+          get_skill_description() {
+            local skill_md="$1"
+            if [ -f "$skill_md" ]; then
+              # Extract description value from YAML frontmatter, take first sentence
+              desc=$(sed -n '/^---$/,/^---$/p' "$skill_md" | grep -A5 '^description:' | sed '1s/^description: *//' | tr '\n' ' ' | sed 's/  */ /g' | sed 's/^ *//' | sed 's/ *---.*$//' | sed 's/\. .*/\./' | head -c 200)
+              echo "$desc"
+            fi
+          }
 
           # Detect new or modified plugins (top-level dirs with .claude-plugin)
           NEW_PLUGINS=""
           UPDATED_PLUGINS=""
           for dir in $(echo "$CHANGED_FILES" | cut -d'/' -f1 | sort -u); do
             if [ -d "$dir/.claude-plugin" ] || [ -f "$dir/.claude-plugin" ]; then
-              # Check if plugin dir was created in the last 7 days
               FIRST_COMMIT=$(git log --diff-filter=A --since="$SINCE" --name-only --pretty=format:"" -- "$dir/" 2>/dev/null | head -1 || true)
               if [ -n "$FIRST_COMMIT" ]; then
-                # Check if the plugin existed before the time window
                 EXISTS_BEFORE=$(git log --until="$SINCE" --oneline -- "$dir/" 2>/dev/null | head -1 || true)
                 if [ -z "$EXISTS_BEFORE" ]; then
                   NEW_PLUGINS="$NEW_PLUGINS$dir\n"
@@ -54,7 +63,7 @@ jobs:
             fi
           done
 
-          # Detect new or modified skills
+          # Detect new or modified skills with descriptions
           NEW_SKILLS=""
           UPDATED_SKILLS=""
           SKILL_CHANGES=$(echo "$CHANGED_FILES" | grep '/skills/' || true)
@@ -63,11 +72,17 @@ jobs:
               skill_name=$(echo "$skill_path" | awk -F'/skills/' '{print $2}' | cut -d'/' -f1)
               plugin_name=$(echo "$skill_path" | cut -d'/' -f1)
               if [ -n "$skill_name" ]; then
+                skill_desc=$(get_skill_description "$skill_path/SKILL.md")
+                if [ -n "$skill_desc" ]; then
+                  label="*${skill_name}* (${plugin_name}) - ${skill_desc}"
+                else
+                  label="*${skill_name}* (${plugin_name})"
+                fi
                 EXISTS_BEFORE=$(git log --until="$SINCE" --oneline -- "$skill_path/" 2>/dev/null | head -1 || true)
                 if [ -z "$EXISTS_BEFORE" ]; then
-                  NEW_SKILLS="$NEW_SKILLS• $skill_name (in $plugin_name)\n"
+                  NEW_SKILLS="${NEW_SKILLS}${label}\n"
                 else
-                  UPDATED_SKILLS="$UPDATED_SKILLS• $skill_name (in $plugin_name)\n"
+                  UPDATED_SKILLS="${UPDATED_SKILLS}${label}\n"
                 fi
               fi
             done
@@ -81,56 +96,43 @@ jobs:
               cmd_name=$(echo "$cmd_path" | awk -F'/commands/' '{print $2}' | cut -d'/' -f1)
               plugin_name=$(echo "$cmd_path" | cut -d'/' -f1)
               if [ -n "$cmd_name" ]; then
-                NEW_COMMANDS="$NEW_COMMANDS• /$cmd_name (in $plugin_name)\n"
+                NEW_COMMANDS="$NEW_COMMANDS/$cmd_name (in $plugin_name)\n"
               fi
             done
           fi
 
-          # Build Slack message
-          if [ "$COMMIT_COUNT" -eq 0 ]; then
-            echo "No changes in the last 7 days. Skipping Slack notification."
-            exit 0
-          fi
-
-          # Construct the blocks JSON
-          BLOCKS='[{"type":"header","text":{"type":"plain_text","text":"📦 Marketplace Weekly Digest","emoji":true}},{"type":"section","text":{"type":"mrkdwn","text":"Here'\''s what changed in the <https://github.com/Casper-Studios/casper-marketplace|Casper Marketplace> this past week."}},{"type":"divider"}'
-
-          # Summary section
-          BLOCKS="$BLOCKS,{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"*📊 Summary*\n${COMMIT_COUNT} commit(s) this week\"}}"
+          # Construct the Slack blocks JSON
+          BLOCKS='[{"type":"header","text":{"type":"plain_text","text":"Marketplace Weekly Digest","emoji":false}},{"type":"section","text":{"type":"mrkdwn","text":"Here'\''s what changed in the <https://github.com/Casper-Studios/casper-marketplace|Casper Marketplace> this past week."}},{"type":"divider"}'
 
           # New plugins
           if [ -n "$NEW_PLUGINS" ]; then
             PLUGIN_LIST=$(echo -e "$NEW_PLUGINS" | sed '/^$/d' | while read -r p; do echo "• *${p}*"; done | tr '\n' '\\' | sed 's/\\/\\n/g' | sed 's/\\n$//')
-            BLOCKS="$BLOCKS,{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"*🆕 New Plugins*\n${PLUGIN_LIST}\"}}"
+            BLOCKS="$BLOCKS,{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"*New Plugins*\n${PLUGIN_LIST}\"}}"
           fi
 
           # Updated plugins
           if [ -n "$UPDATED_PLUGINS" ]; then
             PLUGIN_LIST=$(echo -e "$UPDATED_PLUGINS" | sed '/^$/d' | while read -r p; do echo "• ${p}"; done | tr '\n' '\\' | sed 's/\\/\\n/g' | sed 's/\\n$//')
-            BLOCKS="$BLOCKS,{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"*🔄 Updated Plugins*\n${PLUGIN_LIST}\"}}"
+            BLOCKS="$BLOCKS,{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"*Updated Plugins*\n${PLUGIN_LIST}\"}}"
           fi
 
           # New skills
           if [ -n "$NEW_SKILLS" ]; then
             SKILL_LIST=$(echo -e "$NEW_SKILLS" | sed '/^$/d' | tr '\n' '\\' | sed 's/\\/\\n/g' | sed 's/\\n$//')
-            BLOCKS="$BLOCKS,{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"*✨ New Skills*\n${SKILL_LIST}\"}}"
+            BLOCKS="$BLOCKS,{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"*New Skills*\n${SKILL_LIST}\"}}"
           fi
 
           # Updated skills
           if [ -n "$UPDATED_SKILLS" ]; then
             SKILL_LIST=$(echo -e "$UPDATED_SKILLS" | sed '/^$/d' | tr '\n' '\\' | sed 's/\\/\\n/g' | sed 's/\\n$//')
-            BLOCKS="$BLOCKS,{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"*🔧 Updated Skills*\n${SKILL_LIST}\"}}"
+            BLOCKS="$BLOCKS,{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"*Updated Skills*\n${SKILL_LIST}\"}}"
           fi
 
           # Command changes
           if [ -n "$NEW_COMMANDS" ]; then
             CMD_LIST=$(echo -e "$NEW_COMMANDS" | sed '/^$/d' | tr '\n' '\\' | sed 's/\\/\\n/g' | sed 's/\\n$//')
-            BLOCKS="$BLOCKS,{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"*⚡ Command Changes*\n${CMD_LIST}\"}}"
+            BLOCKS="$BLOCKS,{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"*Command Changes*\n${CMD_LIST}\"}}"
           fi
-
-          # Recent commits
-          COMMIT_LIST=$(echo "$COMMITS" | head -10 | while IFS= read -r line; do echo "• \`$(echo "$line" | cut -d' ' -f1)\` $(echo "$line" | cut -d' ' -f2-)"; done | tr '\n' '\\' | sed 's/\\/\\n/g' | sed 's/\\n$//')
-          BLOCKS="$BLOCKS,{\"type\":\"divider\"},{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"*📝 Recent Commits*\n${COMMIT_LIST}\"}}"
 
           # Footer
           BLOCKS="$BLOCKS,{\"type\":\"context\",\"elements\":[{\"type\":\"mrkdwn\",\"text\":\"Generated automatically every Monday at 9 AM EST\"}]}]"


### PR DESCRIPTION
## Summary
- Adds a GitHub Action that sends a weekly Slack digest every Monday at 9 AM EST via cron (also supports manual trigger)
- Detects new/updated plugins, skills, and commands from the past 7 days
- Each skill includes a 1-sentence description pulled from its SKILL.md frontmatter
- No commit logs or emojis — clean, scannable format

## Test plan
- [ ] Trigger manually via `workflow_dispatch` and verify the Slack message renders correctly
- [ ] Confirm `SLACK_WEBHOOK_URL` secret is configured in the repo
- [ ] Verify skill descriptions are extracted properly for new and updated skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/casper-studios/casper-marketplace/pull/25" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
