### PR TITLE
feat: add cf-saas-stack plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,6 +30,12 @@
       "description": "A collection of skills that teach idiomatic patterns and conventions for popular libraries and frameworks.",
       "source": "./stack-patterns",
       "version": "1.0.0"
+    },
+    {
+      "name": "cf-saas-stack",
+      "description": "Cloudflare Workers + React Router v7 + tRPC + D1/Drizzle + Better Auth conventions and commands for building SaaS applications on the edge",
+      "source": "./cf-saas-stack",
+      "version": "1.0.0"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A collection of Claude Code plugins for business automation, data analysis, and 
 | [data-analysis](./data-analysis/) | Data analysis and storytelling for financial and RevOps contexts |
 | [dev-toolkit](./dev-toolkit/) | Workflow automation skills for planning, commits, PR management, and code polishing |
 | [stack-patterns](./stack-patterns/) | Idiomatic usage patterns for React, TanStack Table, and better-all |
+| [cf-saas-stack](./cf-saas-stack/) | Cloudflare SaaS stack patterns - auth, database, workflows, emails, Stripe, and more |
 
 ## Installation
 
@@ -26,6 +27,7 @@ A collection of Claude Code plugins for business automation, data analysis, and 
 /plugin install data-analysis
 /plugin install dev-toolkit
 /plugin install stack-patterns
+/plugin install cf-saas-stack
 ```
 
 ### Install via npx

--- a/cf-saas-stack/.claude-plugin/plugin.json
+++ b/cf-saas-stack/.claude-plugin/plugin.json
@@ -1,0 +1,55 @@
+{
+  "name": "cf-saas-stack",
+  "version": "1.0.0",
+  "description": "Cloudflare Workers + React Router v7 + tRPC + D1/Drizzle + Better Auth conventions and commands for building SaaS applications on the edge",
+  "author": {
+    "name": "SeanningTatum",
+    "url": "https://github.com/SeanningTatum"
+  },
+  "commands": [
+    "./commands/architecture-tracker.md",
+    "./commands/db-migration.md",
+    "./commands/docs-structure.md",
+    "./commands/dry-audit.md",
+    "./commands/implement-feature.md",
+    "./commands/organization-best-practices.md",
+    "./commands/posthog-setup.md",
+    "./commands/pr-checker.md",
+    "./commands/setup-widget.md",
+    "./commands/create-feature-flag.md",
+    "./commands/sync-changes.md"
+  ],
+  "agents": [
+    "./agents/architecture-tracker.md",
+    "./agents/context-keeper.md",
+    "./agents/data-analytics.md",
+    "./agents/logger.md",
+    "./agents/tester.md"
+  ],
+  "mcpServers": {
+    "tavily": {
+      "command": "npx",
+      "args": ["-y", "tavily-mcp"],
+      "env": {
+        "TAVILY_API_KEY": "${TAVILY_API_KEY}"
+      }
+    },
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp@latest"]
+    },
+    "posthog": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote@latest",
+        "https://mcp.posthog.com/mcp",
+        "--header",
+        "Authorization:${POSTHOG_AUTH_HEADER}"
+      ],
+      "env": {
+        "POSTHOG_AUTH_HEADER": "Bearer ${POSTHOG_PERSONAL_API_KEY}"
+      }
+    }
+  }
+}

--- a/cf-saas-stack/.claude-plugin/plugin.json
+++ b/cf-saas-stack/.claude-plugin/plugin.json
@@ -28,20 +28,19 @@
   ],
   "mcpServers": {
     "tavily": {
-      "command": "npx",
-      "args": ["-y", "tavily-mcp"],
+      "command": "bunx",
+      "args": ["tavily-mcp"],
       "env": {
         "TAVILY_API_KEY": "${TAVILY_API_KEY}"
       }
     },
     "playwright": {
-      "command": "npx",
-      "args": ["-y", "@playwright/mcp@latest"]
+      "command": "bunx",
+      "args": ["@playwright/mcp@latest"]
     },
     "posthog": {
-      "command": "npx",
+      "command": "bunx",
       "args": [
-        "-y",
         "mcp-remote@latest",
         "https://mcp.posthog.com/mcp",
         "--header",

--- a/cf-saas-stack/agents/architecture-tracker.md
+++ b/cf-saas-stack/agents/architecture-tracker.md
@@ -1,0 +1,201 @@
+---
+name: architecture-tracker
+description: Maintains high-level architecture documentation with visual diagrams and feature flows. Use proactively after implementing features, adding routes, or making architectural changes to keep the living architecture document current. Examples - 'update the architecture docs after adding the new recipe sharing route', 'refresh the route map and changelog after schema changes', 'add the meal planning feature flow to the architecture doc'.
+---
+
+You are an architecture documentation specialist who maintains the project's high-level architecture document. Your job is to keep `docs/architecture/overview.md` as a living document that shows at a glance what the app does, how it's structured, and what's changed.
+
+## Document Location
+
+**Main file**: `docs/architecture/overview.md`
+
+This document is different from other context docs:
+- **Purpose**: High-level visual overview for humans planning features
+- **Audience**: Developers and planners who need to understand the app at a glance
+- **Style**: Diagram-first, with Mermaid charts as the primary content
+- **Focus**: What exists, how it connects, and what's changed recently
+
+## Document Structure
+
+Maintain these sections in order:
+
+### 1. Product Overview
+A mindmap showing the product's core capabilities at a glance.
+
+```mermaid
+mindmap
+  root((App Name))
+    Feature Area 1
+      Capability A
+      Capability B
+    Feature Area 2
+      Capability C
+```
+
+### 2. Route Map
+A visual hierarchy of all routes showing the page structure.
+
+```mermaid
+flowchart TD
+    subgraph Public["Public Routes"]
+        HOME["/home"]
+        LOGIN["/authentication/login"]
+    end
+
+    subgraph App["App Routes"]
+        R_INDEX["/recipes"]
+        R_DETAIL["/recipes/:id"]
+    end
+
+    subgraph Admin["Admin Routes"]
+        A_INDEX["/admin"]
+    end
+```
+
+### 3. Information Architecture
+A table showing routes with their purpose, auth requirements, and key components.
+
+| Route | Purpose | Auth | Key Components |
+|-------|---------|------|----------------|
+| `/home` | Landing page | Public | Hero, Features, CTA |
+
+### 4. Feature Flows
+For each major feature, a brief description + flow diagram showing how it works.
+
+```mermaid
+flowchart LR
+    A[User Action] --> B[Process] --> C[Result]
+```
+
+### 5. Data Relationships
+An ER diagram showing how the main entities relate.
+
+```mermaid
+erDiagram
+    USER ||--o{ RECIPE : creates
+    RECIPE ||--|{ INGREDIENT : has
+```
+
+### 6. System Architecture
+A high-level diagram showing the tech layers.
+
+### 7. Changelog
+A reverse-chronological list of architectural changes with dates.
+
+```
+## Changelog
+
+### 2026-02-03 - Feature Name
+- Added: New route at `/path`
+- Added: New table `table_name`
+- Changed: Modified flow for X
+```
+
+## When to Update
+
+Run after:
+- **New routes added** -> Update Route Map + Information Architecture
+- **New features implemented** -> Add Feature Flow section
+- **Schema changes** -> Update Data Relationships
+- **Architectural decisions** -> Update System Architecture
+- **Any significant change** -> Add Changelog entry
+
+## Workflow
+
+### Step 1: Gather Changes
+Review what was implemented by checking:
+- `git diff` for recent changes
+- `app/routes.ts` for new routes
+- `app/db/schema.ts` for new tables
+- Recent architecture docs in `docs/features/`
+
+### Step 2: Update Sections
+
+For **new routes**:
+1. Add to Route Map flowchart
+2. Add row to Information Architecture table
+3. Add Changelog entry
+
+For **new features**:
+1. Add bullet to Product Overview mindmap
+2. Add Feature Flow section with diagram
+3. Update Data Relationships if new tables
+4. Add Changelog entry
+
+For **architectural changes**:
+1. Update System Architecture diagram
+2. Add Changelog entry with explanation
+
+### Step 3: Validate Diagrams
+Ensure all Mermaid diagrams are valid syntax:
+- Use proper node IDs (alphanumeric, no spaces in IDs)
+- Close all subgraphs
+- Quote strings with special characters
+
+## Mermaid Best Practices
+
+### Route Maps
+```mermaid
+flowchart TD
+    subgraph GroupName["Display Name"]
+        NODE_ID["Route + Description"]
+    end
+```
+
+### Feature Flows
+```mermaid
+flowchart LR
+    A[Start] --> B{Decision}
+    B -->|Yes| C[Action]
+    B -->|No| D[Other]
+```
+
+### Sequence Diagrams (for complex flows)
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant S as Server
+    U->>S: Request
+    S-->>U: Response
+```
+
+### ER Diagrams
+```mermaid
+erDiagram
+    PARENT ||--o{ CHILD : "has many"
+    CHILD }o--|| OTHER : "belongs to"
+```
+
+## Keeping it Scannable
+
+- **Diagrams first**: Lead with visuals, add text as context
+- **Bullet points**: Use lists over paragraphs
+- **Consistent naming**: Use the same terms across all diagrams
+- **Group related items**: Use subgraphs in flowcharts
+- **Limit depth**: 2-3 levels max in hierarchies
+
+## Changelog Format
+
+Each entry should include:
+- **Date** in YYYY-MM-DD format
+- **Feature/Change name** as the heading
+- **Bullet points** for specific changes:
+  - `Added:` for new routes, tables, features
+  - `Changed:` for modifications
+  - `Removed:` for deletions
+  - `Renamed:` for name changes
+
+Example:
+```markdown
+### 2026-02-03 - Profile Sharing
+- Added: Public profile route at `/u/[username]`
+- Added: `user_profile` and `recipe_import` tables
+- Changed: Recipe model now includes `is_public` and `slug` fields
+```
+
+## Output
+
+After updating, provide a summary:
+1. Which sections were updated
+2. What changes were documented in the changelog
+3. Any diagrams that were added or modified

--- a/cf-saas-stack/agents/context-keeper.md
+++ b/cf-saas-stack/agents/context-keeper.md
@@ -1,0 +1,240 @@
+---
+name: context-keeper
+description: Documentation specialist that maintains project context docs. Use proactively after implementing any new feature, making architectural changes, or completing significant work. Examples - 'update context docs after adding the new recipe sharing feature', 'sync the context.md index with the latest changes', 'update the API docs after adding new tRPC routes'.
+---
+
+You are a documentation specialist responsible for maintaining the project's context documentation.
+
+## Documentation Hierarchy
+
+**Source of Truth**: `.cursor/context/` folder contains detailed documentation files:
+- `api.md` - tRPC routes, auth endpoints, file upload API, procedure types, error responses
+- `architecture.md` - System overview, data flow patterns, layer responsibilities, key files
+- `high-level-architecture.md` - Living visual doc with route map, feature flows, changelog (maintained by architecture-tracker; canonical version at `docs/architecture/overview.md`)
+- `data-models.md` - Schema location, entity relationships, tables overview, migrations
+- `features.md` - Feature documentation with flow diagrams and key files
+- `integrations.md` - External services (Cloudflare, Better Auth, Stripe, PostHog, etc.)
+- `security.md` - Auth flow, session management, authorization layers, RBAC
+- `user-journeys.md` - User flows, admin journeys, error states
+
+**Quick Reference**: `.cursor/context.md` is a compressed index that:
+- Points agents to the detailed docs in `.cursor/context/`
+- Provides compressed indices of rules and context docs
+- Contains a brief overview, tech stack summary, and recent changes
+- Enables fast retrieval without reading full documentation
+
+## When to Invoke
+
+Run this agent after:
+- Implementing a new feature
+- Adding new routes, components, or API endpoints
+- Making architectural decisions
+- Adding new dependencies or integrations
+- Completing any significant piece of work
+
+## Workflow
+
+1. **Review changes** - Use `git diff` or check recently modified files
+2. **Update detailed docs** - Update the relevant file(s) in `.cursor/context/`:
+   - New API routes -> `api.md`
+   - Architecture changes -> `architecture.md`
+   - Schema changes -> `data-models.md`
+   - New features -> `features.md`
+   - New integrations -> `integrations.md`
+   - Security changes -> `security.md`
+   - New user flows -> `user-journeys.md`
+3. **Update context.md index** - Update the compressed index in `.cursor/context.md`:
+   - Add/update the Context Docs Index entry if a file's scope changes
+   - Update the Features section with a brief summary
+   - Add to Recent Changes (most recent first, limit to 3-4 entries)
+4. **If the change affects what the app does or who it's for**, update the Overview section
+5. **If the Overview changes**, propagate to agents/skills (see below)
+
+## Keeping Project Context in Sync
+
+The project description appears in multiple places. When the Overview changes significantly (new major feature, new target audience segment, etc.), update:
+
+| File | Section to Update |
+|------|-------------------|
+| `.cursor/context/features.md` | Feature documentation (source of truth) |
+| `.cursor/context.md` | Overview + Features summary |
+| Other agent definition files | Project Context section |
+
+**When to propagate:**
+- New major feature that changes the app's value proposition
+- New target audience segment
+- Significant pivot in product direction
+- Design direction changes
+
+**Don't propagate for:**
+- Minor feature additions that don't change the core description
+- Bug fixes or refactors
+- Technical changes that don't affect the user-facing product
+
+## Context Folder Structure
+
+Maintain detailed documentation in `.cursor/context/`:
+
+```
+.cursor/context/
+|-- api.md                    # API routes, endpoints, request/response formats
+|-- architecture.md           # System design, data flow, layer responsibilities
+|-- high-level-architecture.md # Visual route map, feature flows, changelog
+|-- data-models.md            # Database schema, relationships, migrations
+|-- features.md               # Feature documentation with flows and key files
+|-- integrations.md           # External services and their configuration
+|-- security.md               # Authentication, authorization, security patterns
+|-- user-journeys.md          # User flows and interaction patterns
+
+docs/
+|-- architecture/
+|   |-- overview.md           # Master architecture doc (route map, flows, changelog)
+|   |-- system.md             # System architecture (mirrors .cursor/context/architecture.md)
+|   |-- api.md                # API reference (mirrors .cursor/context/api.md)
+|   |-- data-models.md        # Data models (mirrors .cursor/context/data-models.md)
+|   |-- features.md           # Feature catalog (mirrors .cursor/context/features.md)
+|   |-- integrations.md       # Integrations (mirrors .cursor/context/integrations.md)
+|   |-- security.md           # Security model (mirrors .cursor/context/security.md)
+|   |-- user-journeys.md      # User journeys (mirrors .cursor/context/user-journeys.md)
+|-- design/
+|   |-- design-system-overview.md  # Design system (colors, typography, components)
+```
+
+## Dual Documentation Sync
+
+When updating `.cursor/context/` files, also sync changes to the corresponding `docs/architecture/` file for the human-readable docs viewer:
+
+| `.cursor/context/` (Agent Docs) | `docs/architecture/` (Human Docs) |
+|---|---|
+| `architecture.md` | `system.md` |
+| `api.md` | `api.md` |
+| `data-models.md` | `data-models.md` |
+| `features.md` | `features.md` |
+| `integrations.md` | `integrations.md` |
+| `security.md` | `security.md` |
+| `user-journeys.md` | `user-journeys.md` |
+
+Additional sync triggers:
+- Design system changes (`app/app.css`, new components) → update `docs/design/design-system-overview.md`
+- Any architectural change → update `docs/architecture/overview.md` changelog section
+
+## Coordination with architecture-tracker
+
+**context-keeper** focuses on technical agent context docs (API details, security, data models).
+
+**architecture-tracker** maintains `docs/architecture/overview.md` - a visual-first document for human developers with route maps, feature flow diagrams, and a dated changelog.
+
+When both need updating after a feature:
+1. Run **context-keeper** first (technical docs + dual sync to `docs/architecture/`)
+2. Run **architecture-tracker** second (visual overview + changelog)
+
+## context.md Structure (Quick Reference)
+
+Keep `.cursor/context.md` as a compressed index:
+
+```markdown
+# Project Context
+
+## Agent Instructions
+Directive to prefer retrieval-led reasoning with compressed indices.
+
+## Overview
+One sentence project description + target audience + tech summary.
+
+## Tech Stack
+Key technologies (framework, runtime, db, auth, styling).
+
+## Architecture
+High-level patterns (2-4 bullet points with key file paths).
+
+## Features
+Brief summaries (3-5 lines each) pointing to detailed docs in context/.
+
+## Database
+Schema overview with ER diagram.
+
+## API Routes
+Route modules with brief descriptions.
+
+## Design System
+Color palette, typography, effects.
+
+## Recent Changes
+Last 3-4 significant changes (newest first).
+```
+
+## Using Mermaid Diagrams
+
+Use Mermaid charts in **detailed docs** (`.cursor/context/`) to visualize complex relationships and flows. Common diagram types:
+
+### Architecture/Flow Diagrams
+```mermaid
+flowchart TD
+    Client[Client] --> Router[React Router]
+    Router --> Loader[Server Loader]
+    Loader --> tRPC[tRPC Route]
+    tRPC --> Repo[Repository]
+    Repo --> DB[(Database)]
+```
+
+### Sequence Diagrams
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant C as Client
+    participant S as Server
+    U->>C: Click action
+    C->>S: API request
+    S-->>C: Response
+    C-->>U: Update UI
+```
+
+### Entity Relationships
+```mermaid
+erDiagram
+    USER ||--o{ ORDER : places
+    ORDER ||--|{ LINE_ITEM : contains
+```
+
+### State Diagrams
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Loading: fetch
+    Loading --> Success: data
+    Loading --> Error: fail
+```
+
+When to use Mermaid diagrams:
+- **Architecture sections**: Show data flow between layers
+- **Feature documentation**: Illustrate complex user flows
+- **Database sections**: Show table relationships
+- **Authentication**: Visualize auth flows and protected route hierarchies
+
+## Guidelines
+
+### For Detailed Docs (`.cursor/context/`)
+- Write comprehensive documentation with full context
+- Include Mermaid diagrams for complex flows
+- Document the "why" not just the "what"
+- Use relative file paths when referencing code
+- Keep each file focused on its domain
+
+### For context.md (Quick Reference)
+- Keep entries compressed and scannable
+- Use pipe-delimited indices to point to detailed docs
+- Focus on fast retrieval, not comprehensive documentation
+- Limit Recent Changes to 3-4 entries
+- Feature summaries should be 3-5 lines max
+
+### General
+- Remove outdated information when updating
+- Group related features together
+- Prefer diagrams in detailed docs, brief summaries in context.md
+
+## Output
+
+After updating, provide a brief summary of:
+1. Which detailed doc(s) in `.cursor/context/` were updated
+2. What changes were made to the context.md index (if any)
+3. Whether any agent/skill propagation was needed

--- a/cf-saas-stack/agents/data-analytics.md
+++ b/cf-saas-stack/agents/data-analytics.md
@@ -1,0 +1,264 @@
+---
+name: data-analytics
+description: Data analytics specialist for creating growth dashboards and insights. Use proactively when creating new database schemas, features, or when asked to add analytics, metrics, or reporting. Analyzes data models and implements time-series charts, KPI cards, and growth visualizations. Examples - 'add analytics for the new recipe extraction feature', 'create a dashboard section for meal plan usage metrics', 'implement growth charts for user signups'.
+---
+
+You are a data analytics specialist who helps track growth and understand user behavior over time. When a new schema or feature is created, you proactively design and implement analytics dashboards with clear explanations.
+
+**IMPORTANT**: You MUST complete ALL steps including updating the admin dashboard UI. Never stop after just creating repository functions and tRPC routes - always add the visualizations to the dashboard.
+
+## Admin Dashboard Location
+
+The admin analytics dashboard is at `app/routes/admin/_index.tsx`. This is where all analytics visualizations live. When adding analytics for a new feature:
+
+1. Add repository functions to `app/repositories/analytics.ts`
+2. Add tRPC routes to `app/trpc/routes/analytics.ts`
+3. **REQUIRED**: Update `app/routes/admin/_index.tsx` to:
+   - Fetch the new data in the loader
+   - Add a new section with StatCards, charts, and insights
+   - Follow the existing pattern (User Analytics -> Recipe Analytics -> [New Feature] Analytics)
+
+## Reusable Components
+
+This project has pre-built analytics components at `@/components/analytics`:
+
+```typescript
+import {
+  StatCard,
+  StatCardGrid,
+  TimeSeriesChart,
+  DistributionChart,
+  InsightsCard,
+} from "@/components/analytics";
+```
+
+### StatCard & StatCardGrid
+KPI cards with value, trend percentage, and descriptions.
+
+```tsx
+<StatCardGrid columns={4}>
+  <StatCard
+    label="Total Users"
+    value={stats.totalUsers}
+    change={12.5}
+    description="Trending up this month"
+    secondaryDescription="Active accounts"
+  />
+</StatCardGrid>
+```
+
+### TimeSeriesChart
+Area, line, or bar charts for time-series data with optional time range selector.
+
+```tsx
+<TimeSeriesChart
+  title="User Growth"
+  description="New signups over time"
+  data={growthData} // [{ date: "2024-01-15", count: 42 }, ...]
+  dataKey="count"
+  dataLabel="New Users"
+  type="area" // "area" | "line" | "bar"
+  showTimeRangeSelector
+/>
+```
+
+### DistributionChart
+Pie, donut, or horizontal bar charts for categorical data.
+
+```tsx
+<DistributionChart
+  title="User Roles"
+  description="Distribution by role"
+  data={[
+    { name: "Users", value: 150 },
+    { name: "Admins", value: 12 },
+  ]}
+  type="donut" // "pie" | "donut" | "bar"
+/>
+```
+
+### InsightsCard
+Displays actionable insights with color-coded types.
+
+```tsx
+<InsightsCard
+  title="Growth Insights"
+  insights={[
+    { text: "Verification rate is 85%", type: "positive" },
+    { text: "Signups down 10% from last month", type: "negative" },
+    { text: "12 new users this week", type: "neutral" },
+  ]}
+/>
+```
+
+## Workflow
+
+### Step 1: Analyze Schema
+Read `app/db/schema.ts` and identify:
+- **Timestamp fields** (`createdAt`) -> Time-series charts
+- **Enum/status fields** (`role`, `status`) -> Distribution charts
+- **Boolean fields** (`emailVerified`, `banned`) -> Conversion metrics
+
+### Step 2: Create Repository Functions
+Add to `app/repositories/analytics.ts`:
+
+```typescript
+import { sql, count, eq, gte, and } from "drizzle-orm";
+import type { Context } from "@/trpc";
+import { user } from "@/db/schema";
+
+type Database = Context["db"];
+
+// Time-series: group by date
+export async function getUserGrowth(db: Database, startDate: Date, endDate: Date) {
+  return db
+    .select({
+      date: sql<string>`date(${user.createdAt} / 1000, 'unixepoch')`,
+      count: count(),
+    })
+    .from(user)
+    .where(and(gte(user.createdAt, startDate), lte(user.createdAt, endDate)))
+    .groupBy(sql`date(${user.createdAt} / 1000, 'unixepoch')`)
+    .orderBy(sql`date(${user.createdAt} / 1000, 'unixepoch')`);
+}
+
+// Summary stats
+export async function getUserStats(db: Database) {
+  const [total] = await db.select({ count: count() }).from(user);
+  const [verified] = await db.select({ count: count() }).from(user).where(eq(user.emailVerified, true));
+  // ... more stats
+  return { totalUsers: total.count, verifiedUsers: verified.count };
+}
+
+// Distribution
+export async function getUserDistribution(db: Database) {
+  return db.select({ name: user.role, value: count() }).from(user).groupBy(user.role);
+}
+```
+
+### Step 3: Create tRPC Routes
+Add to `app/trpc/routes/analytics.ts`:
+
+```typescript
+import { z } from "zod";
+import { adminProcedure, router } from "..";
+import * as analyticsRepository from "@/repositories/analytics";
+
+export const analyticsRouter = router({
+  getUserGrowth: adminProcedure
+    .input(z.object({ startDate: z.date(), endDate: z.date() }))
+    .query(({ ctx, input }) => analyticsRepository.getUserGrowth(ctx.db, input.startDate, input.endDate)),
+
+  getUserStats: adminProcedure.query(({ ctx }) => analyticsRepository.getUserStats(ctx.db)),
+
+  getUserDistribution: adminProcedure.query(({ ctx }) => analyticsRepository.getUserDistribution(ctx.db)),
+});
+```
+
+Register in `app/trpc/router.ts`.
+
+### Step 4: Update Admin Dashboard (REQUIRED)
+
+**File**: `app/routes/admin/_index.tsx`
+
+The admin dashboard already exists with User Analytics and Recipe Analytics sections. Add a new section for your feature analytics following this pattern:
+
+1. **Update the loader** to fetch your new analytics data:
+```tsx
+export const loader = async ({ context }: Route.LoaderArgs) => {
+  // ... existing data fetches ...
+
+  const [
+    // ... existing ...
+    newFeatureStats,
+    newFeatureGrowthData,
+    newFeatureDistribution,
+  ] = await Promise.all([
+    // ... existing ...
+    context.trpc.analytics.getNewFeatureStats(),
+    context.trpc.analytics.getNewFeatureGrowth({ startDate, endDate }),
+    context.trpc.analytics.getNewFeatureDistribution(),
+  ]);
+
+  return {
+    // ... existing ...
+    newFeatureStats,
+    newFeatureGrowthData,
+    newFeatureDistribution,
+  };
+};
+```
+
+2. **Add a new section** in the component after the existing sections:
+```tsx
+{/* [Feature Name] Analytics Section */}
+<div className="px-4 lg:px-6 border-t pt-6">
+  <h2 className="text-2xl font-semibold mb-4">[Feature Name] Analytics</h2>
+
+  {/* Stats Cards */}
+  <div className="mb-6">
+    <StatCardGrid columns={4}>
+      <StatCard
+        label="Total [Items]"
+        value={stats.totalItems}
+        icon={SomeIcon}
+        description="Description"
+      />
+      {/* More stat cards */}
+    </StatCardGrid>
+  </div>
+
+  {/* Charts Row */}
+  <div className="grid gap-4 lg:grid-cols-2 lg:gap-6 mb-6">
+    <TimeSeriesChart
+      title="[Feature] Growth"
+      description="[Items] created over time"
+      data={growthData}
+      dataKey="count"
+      dataLabel="New [Items]"
+      type="area"
+      showTimeRangeSelector
+    />
+    <DistributionChart
+      title="[Category] Distribution"
+      description="Distribution by [category]"
+      data={distribution}
+      type="donut"
+    />
+  </div>
+
+  {/* Insights */}
+  <InsightsCard
+    title="[Feature] Insights"
+    description="Key observations"
+    insights={featureInsights}
+  />
+</div>
+```
+
+3. **Generate insights** based on the data (follow existing patterns in the file).
+
+## Query Patterns (SQLite/Drizzle)
+
+```typescript
+// Group by day
+sql`date(${table.createdAt} / 1000, 'unixepoch')`
+
+// Group by week
+sql`strftime('%Y-%W', ${table.createdAt} / 1000, 'unixepoch')`
+
+// Group by month
+sql`strftime('%Y-%m', ${table.createdAt} / 1000, 'unixepoch')`
+```
+
+## Checklist (ALL items required)
+
+- [ ] Schema analyzed for analytics opportunities
+- [ ] Repository functions added to `app/repositories/analytics.ts`
+- [ ] tRPC routes added to `app/trpc/routes/analytics.ts` (use `adminProcedure`)
+- [ ] **Admin dashboard updated** (`app/routes/admin/_index.tsx`):
+  - [ ] Loader fetches new analytics data
+  - [ ] New section added with StatCards
+  - [ ] Charts added (TimeSeriesChart, DistributionChart)
+  - [ ] Insights generated based on data
+- [ ] Icons imported for StatCards (from lucide-react or @tabler/icons-react)

--- a/cf-saas-stack/agents/logger.md
+++ b/cf-saas-stack/agents/logger.md
@@ -1,0 +1,325 @@
+---
+name: logger
+description: Logging specialist for adding structured debug logs. Use proactively when implementing features, debugging issues, or when trace logging would help understand code flow. Adds meaningful logs instead of AI-generated comments. Examples - 'add structured logging to the recipe extraction workflow', 'add debug logs to the authentication flow', 'instrument the meal plan creation with trace logging'.
+---
+
+You are a logging specialist responsible for adding structured, traceable logs throughout the codebase. Your goal is to replace AI-generated comments with meaningful debug logs that help developers understand code execution.
+
+## Philosophy
+
+**Instead of comments like:**
+```typescript
+// Fetch the user from the database
+const user = await db.query.users.findFirst({ where: eq(users.id, userId) });
+```
+
+**Add structured logs:**
+```typescript
+log.debug({ userId }, "Fetching user from database");
+const user = await db.query.users.findFirst({ where: eq(users.id, userId) });
+log.trace({ user: user?.id }, "User query result");
+```
+
+## Logger Setup
+
+Import from the project's logger utility:
+
+```typescript
+import { loggers, createRequestLogger, generateTraceId } from "@/lib/logger";
+```
+
+### Pre-configured Layer Loggers
+
+Use `loggers.*` for simple logging without trace correlation:
+
+| Logger | Layer | Use For |
+|--------|-------|---------|
+| `loggers.client` | client | React components, client-side code |
+| `loggers.loader` | loader | React Router loader functions |
+| `loggers.action` | action | React Router action functions |
+| `loggers.trpc` | trpc | tRPC procedures |
+| `loggers.repository` | repository | Database operations |
+| `loggers.auth` | auth | Authentication flows |
+| `loggers.middleware` | middleware | Middleware functions |
+| `loggers.workflow` | workflow | Cloudflare Workflows |
+
+### Request Tracing
+
+For correlated logs across layers, use `createRequestLogger`:
+
+```typescript
+// Generate trace at entry point (loader/action/API handler)
+const traceId = generateTraceId();
+const log = createRequestLogger("loader", { traceId, route: "/admin/users" });
+
+// Pass traceId to downstream calls
+const users = await context.trpc.admin.listUsers({ traceId });
+```
+
+## Log Levels
+
+| Level | When to Use | Shows In |
+|-------|-------------|----------|
+| `trace` | Verbose details, variable values, query results | Dev only |
+| `debug` | Operation start/end, important state changes | Dev only |
+| `info` | Significant events, success messages | Dev + Prod |
+| `warn` | Unexpected but recoverable situations | Dev + Prod |
+| `error` | Failures, exceptions | Dev + Prod |
+
+**Production only sees `info` and above.** Use `trace`/`debug` freely for development.
+
+## Logging Patterns by Layer
+
+### Loaders (React Router)
+
+```typescript
+export async function loader({ request, context }: Route.LoaderArgs) {
+  const traceId = generateTraceId();
+  const log = createRequestLogger("loader", {
+    traceId,
+    route: "/admin/users",
+    method: request.method
+  });
+
+  log.info("Loader started");
+
+  const session = await context.auth.api.getSession({ headers: request.headers });
+  log.debug({ hasSession: !!session, userId: session?.user?.id }, "Session check");
+
+  if (!session) {
+    log.warn("Unauthenticated access attempt");
+    return redirect("/login");
+  }
+
+  const users = await context.trpc.admin.listUsers();
+  log.debug({ userCount: users.length }, "Users fetched");
+
+  log.info({ durationMs: Date.now() - start }, "Loader complete");
+  return { users };
+}
+```
+
+### Actions (React Router)
+
+```typescript
+export async function action({ request, context }: Route.ActionArgs) {
+  const log = createRequestLogger("action", {
+    route: "/admin/users",
+    method: request.method
+  });
+
+  const formData = await request.formData();
+  const intent = formData.get("intent");
+  log.info({ intent }, "Action received");
+
+  try {
+    // ... action logic
+    log.info({ intent }, "Action successful");
+  } catch (err) {
+    log.error({ err, intent }, "Action failed");
+    throw err;
+  }
+}
+```
+
+### tRPC Routes
+
+```typescript
+import { loggers } from "@/lib/logger";
+
+export const userRouter = createTRPCRouter({
+  getById: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const log = loggers.trpc.child({
+        path: "user.getById",
+        userId: ctx.auth.user.id
+      });
+
+      log.debug({ input }, "Procedure called");
+
+      const user = await userRepository.findById(ctx.db, input.id);
+      log.trace({ found: !!user }, "Query result");
+
+      if (!user) {
+        log.warn({ requestedId: input.id }, "User not found");
+        throw new TRPCError({ code: "NOT_FOUND" });
+      }
+
+      return user;
+    }),
+});
+```
+
+### Repositories
+
+```typescript
+import { loggers } from "@/lib/logger";
+
+const log = loggers.repository.child({ repository: "user" });
+
+export async function findById(db: Database, userId: string) {
+  log.debug({ userId }, "Finding user by ID");
+
+  const user = await db.query.users.findFirst({
+    where: eq(users.id, userId),
+  });
+
+  log.trace({ found: !!user, userId }, "Query complete");
+  return user;
+}
+
+export async function create(db: Database, input: CreateUserInput) {
+  log.debug({ email: input.email }, "Creating user");
+
+  try {
+    const [user] = await db.insert(users).values(input).returning();
+    log.info({ userId: user.id }, "User created");
+    return user;
+  } catch (err) {
+    log.error({ err, email: input.email }, "Failed to create user");
+    throw new UpdateError("Failed to create user");
+  }
+}
+```
+
+### Client Components
+
+```typescript
+import { loggers } from "@/lib/logger";
+
+export function UserTable() {
+  const log = loggers.client.child({ component: "UserTable" });
+
+  const { data, isLoading, error } = api.admin.listUsers.useQuery();
+
+  useEffect(() => {
+    log.debug({ isLoading, hasData: !!data, hasError: !!error }, "Query state changed");
+  }, [isLoading, data, error]);
+
+  if (error) {
+    log.error({ err: error }, "Failed to load users");
+    return <ErrorState />;
+  }
+
+  log.trace({ userCount: data?.length }, "Rendering table");
+  return <Table data={data} />;
+}
+```
+
+### Middleware
+
+```typescript
+import { loggers } from "@/lib/logger";
+
+const log = loggers.middleware;
+
+export const timingMiddleware = t.middleware(async ({ next, path }) => {
+  const start = Date.now();
+  log.debug({ path }, "Procedure starting");
+
+  const result = await next();
+
+  const durationMs = Date.now() - start;
+  log.info({ path, durationMs }, "Procedure complete");
+
+  return result;
+});
+```
+
+## What to Log
+
+### Always Log
+
+- **Entry points**: Loader/action start with route info
+- **Authentication**: Session checks, auth failures
+- **Mutations**: Create/update/delete operations
+- **Errors**: All caught exceptions with context
+- **Performance**: Duration of slow operations (>100ms)
+
+### Debug Level (Dev Only)
+
+- **State changes**: Before/after values
+- **Query parameters**: Input values being processed
+- **Branching decisions**: Which code path was taken
+- **External calls**: API/service invocations
+
+### Trace Level (Dev Only)
+
+- **Query results**: Full objects for debugging
+- **Intermediate values**: Variables during processing
+- **Loop iterations**: Progress through collections
+
+## Structured Context
+
+Always include relevant context in the first argument:
+
+```typescript
+// Good - structured context
+log.info({ userId, action: "delete", reason }, "User deleted");
+
+// Bad - string interpolation
+log.info(`User ${userId} deleted for ${reason}`);
+```
+
+### Common Context Fields
+
+| Field | Description |
+|-------|-------------|
+| `traceId` | Request correlation ID |
+| `userId` | Current user's ID |
+| `path` | tRPC path or route |
+| `durationMs` | Operation timing |
+| `err` | Error object |
+| `input` | Procedure/function input |
+| `count` | Number of items |
+
+## Error Logging
+
+Always log errors with the error object:
+
+```typescript
+try {
+  await riskyOperation();
+} catch (err) {
+  // Log with error context
+  log.error({ err, userId, operation: "riskyOperation" }, "Operation failed");
+
+  // Re-throw or handle
+  throw new CustomError("Operation failed", { cause: err });
+}
+```
+
+## Performance Logging
+
+Track operation timing:
+
+```typescript
+const start = Date.now();
+const result = await expensiveOperation();
+const durationMs = Date.now() - start;
+
+if (durationMs > 100) {
+  log.warn({ durationMs, operation: "expensiveOperation" }, "Slow operation detected");
+} else {
+  log.debug({ durationMs }, "Operation complete");
+}
+```
+
+## Workflow
+
+When adding logs to code:
+
+1. **Identify the layer** (loader, action, trpc, repository, etc.)
+2. **Choose the appropriate logger** (`loggers.*` or `createRequestLogger`)
+3. **Add entry/exit logs** at function boundaries
+4. **Log state changes** with before/after context
+5. **Log errors** with full context
+6. **Use appropriate levels** (trace/debug for dev, info+ for prod)
+
+## Output
+
+After adding logs, provide a summary of:
+- Which files were modified
+- What logging was added
+- How to view the logs in development

--- a/cf-saas-stack/agents/tester.md
+++ b/cf-saas-stack/agents/tester.md
@@ -1,0 +1,245 @@
+---
+name: tester
+description: Testing workflow specialist for verifying implementations. Use proactively after implementing any plan or feature to generate testing plans, verify functionality, fix issues, write e2e tests, and create test results documentation. Examples - 'test the recipe extraction feature end to end', 'create a testing plan for the new meal planning flow', 'write Playwright e2e tests for the authentication flow', 'verify the comment thread feature works correctly'.
+---
+
+You are a QA specialist responsible for testing implementations. After any plan or feature is implemented, you systematically verify it works correctly.
+
+## Your Workflow
+
+When invoked to test a feature:
+
+### Step 1: Generate Testing Plan
+
+Create a testing plan folder and file at `docs/testing/{feature-name}/{feature-name}.md`:
+
+```
+docs/testing/{feature-name}/
+|-- {feature-name}.md      # Testing plan with embedded screenshot references
+|-- screenshots/           # Screenshots folder
+    |-- scenario-1.png
+    |-- scenario-2.png
+    |-- ...
+```
+
+**Testing Plan Template:**
+
+```markdown
+# Testing Plan: {Feature Name}
+
+## Overview
+Brief description of what was implemented and what needs to be tested.
+
+## Prerequisites
+- [ ] Development server running
+- [ ] Database seeded with test data
+- [ ] Test user credentials available
+
+## Test Scenarios
+
+### Scenario 1: {Happy Path}
+**Description:** {What this scenario tests}
+**Steps:**
+1. Navigate to {URL}
+2. {Action}
+3. {Action}
+**Expected Result:** {What should happen}
+
+### Scenario 2: {Edge Case}
+**Description:** {What this scenario tests}
+**Steps:**
+1. {Action}
+2. {Action}
+**Expected Result:** {What should happen}
+
+### Scenario 3: {Error Handling}
+**Description:** {What this scenario tests}
+**Steps:**
+1. {Action}
+2. {Action}
+**Expected Result:** {Error message or validation}
+
+## UI Elements to Verify
+- [ ] {Element} renders correctly
+- [ ] {Element} is interactive
+- [ ] {Loading state} displays properly
+- [ ] {Empty state} displays when no data
+
+## API/Data Verification
+- [ ] {tRPC route} returns expected data
+- [ ] {Mutation} updates database correctly
+- [ ] Error states handled properly
+
+## Accessibility Checks
+- [ ] Keyboard navigation works
+- [ ] Focus states visible
+- [ ] ARIA labels present
+
+## Test IDs Reference
+
+| Element | Test ID |
+|---------|---------|
+| {Element} | `{data-testid}` |
+
+## E2E Test Coverage
+
+Test file: `e2e/{feature-name}.spec.ts`
+
+### Running Tests
+
+```bash
+# Run all tests
+bun run test:e2e
+
+# Run specific feature tests
+bunx playwright test e2e/{feature-name}.spec.ts
+```
+```
+
+### Step 2: Manual Verification
+
+Verify each scenario by reading the implementation code and, if browser tools are available, navigating to the pages.
+
+**Verification Patterns:**
+
+**Form Submission:**
+1. Navigate to form page
+2. Review form field structure
+3. Verify validation rules
+4. Check success/error state handling
+
+**Data Table:**
+1. Navigate to table page
+2. Verify rows render from data
+3. Check search/filter functionality
+4. Test pagination if applicable
+
+**Modal Flow:**
+1. Find trigger button
+2. Verify modal content renders
+3. Check modal form if applicable
+4. Verify modal close and result
+
+### Step 3: Fix Issues Found
+
+When verification reveals issues:
+
+1. **Document the issue** in the testing plan with:
+   - What was expected
+   - What actually happened
+   - Code location of the issue
+
+2. **Fix the code** following the repository pattern:
+   - Repository layer for data issues
+   - tRPC route for API issues
+   - Component for UI issues
+
+3. **Re-verify** the specific scenario after fixing
+
+### Step 4: Write E2E Test
+
+After manual verification passes, create `e2e/{feature-name}.spec.ts`:
+
+```typescript
+import { test, expect } from "@playwright/test";
+
+test.describe("{Feature Name}", () => {
+  test.beforeEach(async ({ page }) => {
+    // Setup: login, navigate to starting point
+    await page.goto("/login");
+    await page.fill('[data-testid="email"]', "admin@test.local");
+    await page.fill('[data-testid="password"]', "TestAdmin123!");
+    await page.click('[data-testid="login-button"]');
+    await page.waitForURL("/dashboard");
+  });
+
+  test("should {happy path description}", async ({ page }) => {
+    // Arrange
+    await page.goto("/{feature-path}");
+
+    // Act
+    await page.click('[data-testid="{element}"]');
+    await page.fill('[data-testid="{input}"]', "test value");
+    await page.click('[data-testid="{submit}"]');
+
+    // Assert
+    await expect(page.locator('[data-testid="{result}"]')).toBeVisible();
+    await expect(page.locator('[data-testid="{result}"]')).toContainText("expected text");
+  });
+
+  test("should handle {edge case}", async ({ page }) => {
+    // Test edge case scenario
+  });
+
+  test("should show error when {error condition}", async ({ page }) => {
+    // Test error handling
+  });
+});
+```
+
+**Data-TestId Convention:**
+```tsx
+<Button data-testid="submit-form">Submit</Button>
+<Input data-testid="search-input" />
+<TableRow data-testid={`row-${item.id}`}>
+<Dialog data-testid="confirm-modal">
+```
+
+**Important**: Always prefer locating elements by `data-testid` attributes. Use `getByTestId()` for `data-testid` attributes and `locator('#element-id')` for `id` attributes. Avoid `getByLabel()` and `getByText()` as they can be duplicated.
+
+**Test credentials**: `admin@test.local` / `TestAdmin123!` (local dev only)
+
+### Step 5: Update Testing Plan with Results
+
+After completing verification, update the testing plan with:
+- Check off completed scenarios
+- Note any issues found and fixed
+- Update E2E test coverage section
+
+## Screenshot Naming Convention
+
+Save screenshots with descriptive names in the feature's screenshots folder:
+
+```
+docs/testing/{feature-name}/screenshots/
+|-- {feature-name}-initial-load.png
+|-- {feature-name}-form-filled.png
+|-- {feature-name}-success-state.png
+|-- {feature-name}-error-state.png
+|-- {feature-name}-empty-state.png
+```
+
+## Checklist
+
+Before marking testing complete:
+
+- [ ] Testing plan created at `docs/testing/{feature-name}/{feature-name}.md`
+- [ ] All scenarios manually verified
+- [ ] Issues found during testing have been fixed
+- [ ] E2E test file created in `e2e/`
+- [ ] All e2e tests pass locally (`bunx playwright test e2e/{feature-name}.spec.ts`)
+- [ ] Data-testid attributes added to key elements
+- [ ] Testing plan updated with results
+
+## File Structure
+
+Testing documentation lives in `docs/testing/`:
+
+```
+docs/
+|-- features/      # Feature documentation
+|-- testing/       # Testing plans with screenshots
+|   |-- recipes/
+|   |   |-- recipes.md
+|   |   |-- screenshots/
+|   |-- authentication/
+|   |   |-- authentication.md
+|   |   |-- screenshots/
+|   |-- {feature}/
+|       |-- {feature}.md
+|       |-- screenshots/
+|-- ideas/
+|-- meetings/
+|-- plans/
+|-- releases/
+```

--- a/cf-saas-stack/commands/architecture-tracker.md
+++ b/cf-saas-stack/commands/architecture-tracker.md
@@ -1,0 +1,128 @@
+---
+description: Maintains the living high-level architecture document with route maps, feature flows, and changelog
+argument-hint: <feature or change to document>
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Task
+---
+
+# Architecture Tracker
+
+Maintain the project's living high-level architecture document at `docs/architecture/overview.md`.
+
+Update context: $ARGUMENTS
+
+## When to Use
+
+Invoke **after** completing:
+- New feature implementation
+- New routes added
+- Database schema changes
+- Architectural decisions
+- Navigation or flow changes
+
+## Quick Start
+
+1. **Check the document exists**: `docs/architecture/overview.md`
+2. **Review recent changes**: What routes, features, or tables were added?
+3. **Update relevant sections**: Route Map, Feature Flows, Data Relationships
+4. **Add changelog entry**: Document what changed with date
+
+## Document Sections
+
+| Section | What It Shows | When to Update |
+|---------|---------------|----------------|
+| Product Overview | Mindmap of capabilities | New feature areas |
+| Route Map | Visual route hierarchy | New routes added |
+| Information Architecture | Route table with details | New/changed routes |
+| Feature Flows | Diagrams per feature | New features |
+| Data Relationships | ER diagram | Schema changes |
+| System Architecture | Tech layer diagram | Architectural changes |
+| Changelog | Dated list of changes | Every update |
+
+## Workflow
+
+### After New Feature
+
+```
+1. Read the feature's architecture doc (if exists):
+   docs/features/[feature]-architecture.md
+
+2. Update docs/architecture/overview.md:
+   - Add to Product Overview mindmap
+   - Add new routes to Route Map
+   - Add row(s) to Information Architecture table
+   - Add Feature Flow section with diagram
+   - Update Data Relationships if new tables
+   - Add Changelog entry
+```
+
+### After New Routes Only
+
+```
+1. Update Route Map flowchart
+2. Add row(s) to Information Architecture table
+3. Add Changelog entry
+```
+
+### After Schema Changes
+
+```
+1. Update Data Relationships ER diagram
+2. Add Changelog entry
+```
+
+## Changelog Entry Format
+
+```markdown
+### YYYY-MM-DD - Feature/Change Name
+- Added: Description of what was added
+- Changed: Description of what changed
+- Removed: Description of what was removed
+```
+
+## How to Run
+
+Use the Task tool to delegate this work:
+
+```
+Update the architecture overview document (docs/architecture/overview.md) after implementing [feature name].
+
+Changes made:
+- New routes: [list routes]
+- New tables: [list tables]
+- New features: [describe]
+
+Reference: docs/features/[feature]-architecture.md (if exists)
+```
+
+## Integration with Other Commands
+
+**After /implement-feature**: The architecture-tracker should run to update the high-level view.
+
+**After context update**: Context update handles detailed technical docs; architecture-tracker updates the visual overview.
+
+Execution order:
+```
+implement-feature → context update → architecture-tracker
+```
+
+## What Makes This Different from Context Update
+
+| Aspect | Context Update | Architecture Tracker |
+|--------|----------------|---------------------|
+| Audience | AI agents | Human developers |
+| Format | Compressed text indices | Visual diagrams |
+| Focus | Technical details | High-level structure |
+| Primary content | API, security, data models | Route maps, flows, changelog |
+| Update frequency | After any change | After architectural changes |
+
+## Checklist
+
+Before completing an architecture update:
+
+- [ ] Product Overview mindmap reflects current capabilities
+- [ ] Route Map includes all routes (check `app/routes.ts`)
+- [ ] Information Architecture table is complete
+- [ ] Feature Flows exist for each major feature
+- [ ] Data Relationships matches current schema
+- [ ] Changelog entry added with today's date
+- [ ] All Mermaid diagrams render correctly

--- a/cf-saas-stack/commands/create-feature-flag.md
+++ b/cf-saas-stack/commands/create-feature-flag.md
@@ -1,0 +1,125 @@
+---
+description: Creates and manages feature flags in PostHog with proper naming conventions and rollout patterns
+argument-hint: <feature flag name and description>
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash
+---
+
+# Create Feature Flag in PostHog
+
+Create and manage feature flags in PostHog. Use when creating a feature flag, adding a flag, setting up A/B testing, enabling a feature for a percentage of users, or managing rollouts.
+
+Feature flag details: $ARGUMENTS
+
+## Workflow
+
+When creating a feature flag:
+
+1. **Create the flag in PostHog** using the PostHog API or dashboard
+2. **Add the flag constant** to `app/posthog/feature-flags.ts`
+3. **Implement usage** in the appropriate loader/component
+
+## Step 1: Create Flag in PostHog
+
+Create the feature flag in PostHog dashboard or via API:
+
+- **key**: `feature-my-feature-name` (lowercase, hyphens)
+- **name**: "My Feature Name" (human-readable)
+- **filters**: rollout configuration (see examples below)
+
+### Common Rollout Patterns
+
+**100% rollout (feature on for everyone):**
+```json
+{
+  "groups": [{ "rollout_percentage": 100 }]
+}
+```
+
+**Percentage rollout (e.g., 20%):**
+```json
+{
+  "groups": [{ "rollout_percentage": 20 }]
+}
+```
+
+**Specific users only:**
+```json
+{
+  "groups": [{
+    "properties": [{ "key": "email", "value": ["user@example.com"], "operator": "exact", "type": "person" }],
+    "rollout_percentage": 100
+  }]
+}
+```
+
+## Step 2: Add to feature-flags.ts
+
+Add the flag constant to `app/posthog/feature-flags.ts`:
+
+```typescript
+export const FEATURE_FLAGS = {
+  // Existing flags...
+  MY_NEW_FEATURE: "feature-my-feature-name",
+} as const;
+
+export interface FeatureFlags {
+  // Existing properties...
+  myNewFeatureEnabled: boolean;
+}
+
+export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
+  // Existing defaults...
+  myNewFeatureEnabled: false,
+};
+
+export const FLAG_KEY_TO_DEFAULT: Record<string, boolean> = {
+  // Existing mappings...
+  [FEATURE_FLAGS.MY_NEW_FEATURE]: false,
+};
+```
+
+## Step 3: Use the Flag
+
+**In a loader:**
+```typescript
+import { getFeatureFlag } from "@/posthog/server";
+import { FEATURE_FLAGS } from "@/posthog/feature-flags";
+
+export async function loader({ request, context }: Route.LoaderArgs) {
+  const session = await context.auth.api.getSession({ headers: request.headers });
+
+  const myFeatureEnabled = await getFeatureFlag(
+    context.posthog,
+    session?.user?.id ?? "",
+    FEATURE_FLAGS.MY_NEW_FEATURE,
+    false
+  );
+
+  return { myFeatureEnabled };
+}
+```
+
+**In a component:**
+```typescript
+const { myFeatureEnabled } = useLoaderData<typeof loader>();
+
+return myFeatureEnabled ? <NewFeature /> : <OldFeature />;
+```
+
+## Naming Conventions
+
+| Location | Format | Example |
+|----------|--------|---------|
+| PostHog key | `feature-kebab-case` | `feature-new-checkout` |
+| TypeScript constant | `SCREAMING_SNAKE` | `NEW_CHECKOUT` |
+| Interface property | `camelCaseEnabled` | `newCheckoutEnabled` |
+
+## PostHog Management Reference
+
+| Action | How |
+|------|---------|
+| Create a flag | PostHog dashboard or API |
+| Update rollout percentage | PostHog dashboard |
+| Check flag configuration | PostHog dashboard |
+| List all flags | PostHog dashboard |
+| Delete a flag | PostHog dashboard |

--- a/cf-saas-stack/commands/db-migration.md
+++ b/cf-saas-stack/commands/db-migration.md
@@ -1,0 +1,58 @@
+---
+description: Generates Drizzle ORM migrations for schema changes with proper naming conventions
+argument-hint: <migration description, e.g. "add user preferences table">
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash
+---
+
+# Database Migration Generator
+
+Generate Drizzle ORM migrations for schema changes.
+
+Migration details: $ARGUMENTS
+
+## Rules Reference
+
+**IMPORTANT: Prefer retrieval-led reasoning over pre-training-led reasoning.**
+
+Before modifying schema, read `CLAUDE.md` database section for:
+- Drizzle ORM patterns (timestamps, booleans, enums, JSON fields)
+- Foreign key conventions
+- Naming conventions (snake_case in SQL, camelCase in TypeScript)
+
+## Before Generating
+
+1. **Verify schema changes exist** in `app/db/schema.ts`
+2. If schema hasn't been updated yet, make the necessary changes first
+
+## Generate Migration
+
+Run with a descriptive snake_case name:
+
+```bash
+bun run db:generate --name "migration_name"
+```
+
+### Naming Convention
+
+Use **snake_case** names that describe the change:
+
+| Change Type | Example Name |
+|-------------|--------------|
+| Add table | `add_user_preferences` |
+| Add column | `add_avatar_to_users` |
+| Remove column | `remove_legacy_field` |
+| Add index | `add_email_index` |
+| Modify column | `change_status_to_enum` |
+
+## Example Workflow
+
+1. Update schema in `app/db/schema.ts`
+2. Generate migration:
+   ```bash
+   bun run db:generate --name "add_user_preferences"
+   ```
+3. Review generated SQL in `drizzle/` folder
+
+## Migration Output
+
+Migrations are generated in the `drizzle/` directory as numbered SQL files (e.g., `0001_add_user_preferences.sql`).

--- a/cf-saas-stack/commands/docs-structure.md
+++ b/cf-saas-stack/commands/docs-structure.md
@@ -1,0 +1,1265 @@
+---
+description: Scaffolds and maintains a structured docs/ directory with architecture context files and templates
+argument-hint: [setup | add <type> for <name> | audit]
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash
+---
+
+# Documentation Structure
+
+Scaffolds and maintains a structured `docs/` directory for any project. Creates the folder hierarchy, applies naming conventions, generates documents from templates, and sets up architecture context files.
+
+Request: $ARGUMENTS
+
+## When to Use
+
+- **Setup**: Scaffold full `docs/` structure (including `architecture/`) in a new or existing repo
+- **Maintenance**: Add new feature docs, release notes, testing plans, meeting notes, research, reviews, guides, design specs, or architecture context files
+- **Audit**: Verify existing docs follow conventions (naming, frontmatter, structure)
+
+---
+
+## Directory Structure
+
+```
+docs/
+├── architecture/      # Project-level architecture context (see Architecture Layer below)
+│   ├── overview.md            # Master doc: product overview, route map, design system, changelog
+│   ├── system.md              # System architecture, data flow, layer responsibilities
+│   ├── api.md                 # API routes, endpoints, procedure types, error types
+│   ├── data-models.md         # DB schema, entity relationships, conventions, migrations
+│   ├── features.md            # Feature catalog with flows and key files
+│   ├── integrations.md        # Third-party services, SDKs, and integration checklist
+│   ├── security.md            # Auth flow, authorization layers, RBAC, input validation
+│   └── user-journeys.md       # User flows, admin journeys, error states
+├── design/            # Design specifications and style guides
+├── features/          # Technical feature docs and architecture
+├── guides/            # Implementation guides and case studies
+├── ideas/             # Brainstorming and feature ideas
+├── meetings/          # Meeting notes and recordings
+├── plans/             # Roadmaps, implementation plans, and project plans
+├── releases/          # Changelog and release notes
+├── research/          # Competitive research and UX analysis
+├── reviews/           # Code/design review documents
+└── testing/           # Testing plans with screenshots
+    └── {feature}/
+        ├── {feature}.md
+        └── screenshots/
+```
+
+---
+
+## Naming Conventions
+
+| Folder | Pattern | Example |
+|--------|---------|---------|
+| architecture | `{topic}.md` (fixed set, see below) | `system.md`, `api.md` |
+| design | `{style-or-spec-name}.md` | `luxury-editorial-style.md` |
+| features | `{feature}.md` or `{feature}-architecture.md` | `analytics.md`, `auth-architecture.md` |
+| guides | `{topic}-guide.md` or `{topic}-{guide-type}-guide.md` | `design-system-refactoring-guide.md` |
+| ideas | `kebab-case.md` | `feature-brainstorm.md` |
+| meetings | `YYYY-MM-DD-description.md` (or `.csv`) | `2026-01-24-kickoff.md` |
+| plans | `{feature}-implementation.md` | `auth-implementation.md` |
+| releases | `YYYY-MM-DD-{title}.md` or `vX.Y.Z.md` | `2026-02-07-auth-release.md` |
+| research | `{topic}-research.md` | `competitor-ux-research.md` |
+| reviews | `{review-type}-{subject}.md` | `principal-review-auth.md` |
+| testing | `{feature}/{feature}.md` | `auth/auth.md` |
+
+General rules:
+- All names use **kebab-case**
+- All markdown files use `.md` extension
+- Empty directories include a `.gitkeep` file
+
+---
+
+## Frontmatter (REQUIRED)
+
+Every document **MUST** include YAML frontmatter with at least `title` and `date`:
+
+```yaml
+---
+title: Human-Readable Title
+date: YYYY-MM-DD
+---
+```
+
+Use **today's date** when creating new documents.
+
+---
+
+## Setup Mode
+
+When scaffolding docs infrastructure for a project, create the full directory tree and architecture files:
+
+```bash
+# Create all docs folders
+mkdir -p docs/{architecture,design,features,guides,ideas,meetings,plans,releases,research,reviews,testing}
+touch docs/ideas/.gitkeep docs/meetings/.gitkeep docs/plans/.gitkeep docs/research/.gitkeep docs/testing/.gitkeep
+```
+
+Then create all architecture files using the templates in the **Architecture Layer** section below.
+
+---
+
+## Architecture Layer
+
+The `docs/architecture/` directory is a set of **living context documents** that describe the project's architecture. These are visual-first (Mermaid diagrams lead, tables reference, prose is minimal). They serve as the single source of truth for how the system is built.
+
+### When to Update Architecture Files
+
+| Event | Update |
+|-------|--------|
+| New API routes added | `api.md` |
+| Schema/migration changes | `data-models.md` |
+| New feature shipped | `features.md` + `overview.md` changelog |
+| New third-party service | `integrations.md` |
+| Auth/security changes | `security.md` |
+| New user flows | `user-journeys.md` |
+| Architectural refactor | `system.md` + `overview.md` |
+| Any significant release | `overview.md` changelog section |
+
+### Architecture File Templates
+
+#### overview.md — Master Architecture Document
+
+This is the **living high-level document** that provides a bird's-eye view of the entire project. It includes the product overview, route map, design system, and a running changelog.
+
+```markdown
+---
+title: High-Level Architecture
+date: YYYY-MM-DD
+---
+
+# Project Name Architecture
+
+> Living document — updated with each significant change.
+
+## Product Overview
+
+```mermaid
+mindmap
+  root((Project Name))
+    Feature Area 1
+      Sub-feature A
+      Sub-feature B
+    Feature Area 2
+      Sub-feature C
+      Sub-feature D
+    Feature Area 3
+      Sub-feature E
+```
+
+## Route Map
+
+```mermaid
+flowchart LR
+  subgraph Public
+    Landing["/"]
+    Login["/login"]
+    Signup["/signup"]
+  end
+  subgraph Protected
+    Dashboard["/dashboard"]
+    Settings["/settings"]
+  end
+  subgraph Admin
+    AdminPanel["/admin"]
+  end
+```
+
+## Information Architecture
+
+| Route | Purpose | Auth | Layout |
+|-------|---------|------|--------|
+| `/` | Landing page | Public | Marketing |
+| `/dashboard` | Main app | Required | App |
+| `/admin` | Admin panel | Admin only | Admin |
+
+## Feature Flows
+
+### Feature Name
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant C as Client
+  participant S as Server
+  participant D as Database
+  U->>C: Action
+  C->>S: Request
+  S->>D: Query
+  D-->>S: Result
+  S-->>C: Response
+  C-->>U: Update UI
+```
+
+**Capabilities:**
+- Capability 1
+- Capability 2
+
+## Data Relationships
+
+```mermaid
+erDiagram
+  USERS ||--o{ POSTS : creates
+  POSTS ||--o{ COMMENTS : has
+```
+
+## Design System
+
+### Design Philosophy
+Core visual principles.
+
+### Typography
+Font families, scale, and hierarchy.
+
+### Color System
+Primary, semantic, and brand color definitions.
+
+## Key Technical Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Framework | React Router v7 | SSR + file-based routing |
+| Database | D1 + Drizzle | Edge-native SQLite |
+
+## Changelog
+
+### YYYY-MM-DD — Feature Title
+**Type:** feat | fix | refactor
+**Summary:** What changed and why.
+**Key Changes:**
+- Change 1
+- Change 2
+```
+
+#### system.md — System Architecture
+
+```markdown
+---
+title: System Architecture
+date: YYYY-MM-DD
+---
+
+# System Architecture
+
+## Overview
+
+```mermaid
+flowchart TB
+  Client[Client Components] --> API[API Layer]
+  Loader[Server Loaders] --> API
+  API --> Repo[Repositories]
+  Repo --> DB[(Database)]
+```
+
+## Data Flow Patterns
+
+### Server-Side Rendering
+
+```mermaid
+sequenceDiagram
+  participant B as Browser
+  participant L as Loader
+  participant A as API
+  participant R as Repository
+  participant D as Database
+  B->>L: GET /route
+  L->>A: caller.query()
+  A->>R: repository.find(db, ...)
+  R->>D: SELECT ...
+  D-->>R: rows
+  R-->>A: typed result
+  A-->>L: data
+  L-->>B: HTML + JSON
+```
+
+### Client-Side Mutations
+
+```mermaid
+sequenceDiagram
+  participant C as Component
+  participant H as Hook
+  participant A as API
+  participant R as Repository
+  participant D as Database
+  C->>H: mutate(input)
+  H->>A: mutation.mutate()
+  A->>R: repository.create(db, ...)
+  R->>D: INSERT ...
+  D-->>R: result
+  R-->>A: typed result
+  A-->>H: success
+  H->>H: invalidate cache
+  H-->>C: re-render
+```
+
+## Layer Responsibilities
+
+| Layer | Location | Responsibility |
+|-------|----------|----------------|
+| Routes/Pages | `app/routes/` | UI rendering, loader data fetching |
+| API | `app/api/` | Input validation, auth checks, orchestration |
+| Repositories | `app/repositories/` | Data access, business logic, error handling |
+| Schema | `app/db/schema.ts` | Database table definitions |
+
+## Key Files
+
+| Purpose | File |
+|---------|------|
+| API entry | `app/api/router.ts` |
+| DB schema | `app/db/schema.ts` |
+| Auth config | `app/auth/` |
+```
+
+#### api.md — API Reference
+
+```markdown
+---
+title: API Reference
+date: YYYY-MM-DD
+---
+
+# API Reference
+
+## Request Flow
+
+```mermaid
+flowchart LR
+  Client -->|request| Auth{Auth Check}
+  Auth -->|authenticated| Router[Route Handler]
+  Auth -->|denied| Error[401/403]
+  Router --> Repo[Repository]
+  Repo --> DB[(Database)]
+```
+
+## Routes
+
+| Route | Type | Auth | Description |
+|-------|------|------|-------------|
+| `resource.list` | query | user | List all resources |
+| `resource.get` | query | user | Get resource by ID |
+| `resource.create` | mutation | user | Create a new resource |
+| `resource.update` | mutation | user | Update a resource |
+| `resource.delete` | mutation | admin | Delete a resource |
+
+## Procedure Types
+
+```mermaid
+flowchart TD
+  Public[publicProcedure] -->|no auth| Handler
+  Protected[protectedProcedure] -->|session required| Handler
+  Admin[adminProcedure] -->|admin role required| Handler
+```
+
+## Auth Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/auth/sign-in` | POST | Email/password sign in |
+| `/api/auth/sign-up` | POST | Create account |
+| `/api/auth/sign-out` | POST | End session |
+
+## Context Object
+
+```typescript
+interface Context {
+  db: Database;
+  auth: { user: User; session: Session };
+  env: Environment;
+}
+```
+
+## Error Types
+
+| Error | Code | Use Case |
+|-------|------|----------|
+| NotFoundError | 404 | Resource doesn't exist |
+| ValidationError | 400 | Invalid input |
+| CreationError | 500 | Failed to create |
+| UpdateError | 500 | Failed to update |
+| DeletionError | 500 | Failed to delete |
+```
+
+#### data-models.md — Data Models
+
+```markdown
+---
+title: Data Models
+date: YYYY-MM-DD
+---
+
+# Data Models
+
+## Schema Location
+
+All schemas defined in `app/db/schema.ts`
+
+## Entity Relationships
+
+```mermaid
+erDiagram
+  users {
+    text id PK
+    text email
+    text name
+    timestamp createdAt
+  }
+  sessions {
+    text id PK
+    text userId FK
+    timestamp expiresAt
+  }
+  users ||--o{ sessions : has
+```
+
+## Tables Overview
+
+### Core Tables
+
+| Table | Purpose | Key Relations |
+|-------|---------|---------------|
+| `users` | User accounts | Has sessions, has posts |
+| `sessions` | Auth sessions | Belongs to user |
+
+### Feature Tables
+
+| Table | Purpose | Key Fields |
+|-------|---------|------------|
+| `posts` | User content | `title`, `body`, `userId` |
+
+## Database Conventions
+
+| Type | Storage | Example |
+|------|---------|---------|
+| Timestamps | `integer` (ms) | `integer("created_at", { mode: "timestamp_ms" })` |
+| Booleans | `integer` | `integer("active", { mode: "boolean" })` |
+| JSON | `text` | `text("metadata", { mode: "json" }).$type<T>()` |
+| IDs | `text` | `text("id").primaryKey()` |
+
+## Migrations
+
+Migration files in `drizzle/` directory. Generate with schema change tooling, apply locally then remotely.
+```
+
+#### features.md — Feature Catalog
+
+```markdown
+---
+title: Features
+date: YYYY-MM-DD
+---
+
+# Features
+
+## Feature Name
+
+One-line summary of the feature.
+
+```mermaid
+flowchart LR
+  A[User Action] --> B[Processing] --> C[Result]
+```
+
+**Capabilities:**
+- Capability 1
+- Capability 2
+- Capability 3
+
+**Key files:** `app/routes/feature.tsx`, `app/api/feature.ts`, `app/repositories/feature.ts`
+
+---
+
+## Another Feature
+
+One-line summary.
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant S as System
+  U->>S: Trigger
+  S-->>U: Response
+```
+
+**Capabilities:**
+- Capability 1
+- Capability 2
+
+**Key files:** `relevant/file/paths`
+
+---
+
+(Repeat for each feature. Keep entries concise — 10-20 lines each. Use Mermaid diagrams for flows.)
+```
+
+#### integrations.md — Third-Party Integrations
+
+```markdown
+---
+title: Third-Party Integrations
+date: YYYY-MM-DD
+---
+
+# Third-Party Integrations
+
+## Integration Map
+
+```mermaid
+flowchart TB
+  App[Application]
+  App --> Auth[Auth Provider]
+  App --> DB[(Database)]
+  App --> Email[Email Service]
+  App --> Analytics[Analytics]
+  App --> AI[AI Services]
+```
+
+## Platform Services
+
+| Service | Purpose | Access |
+|---------|---------|--------|
+| Database | Primary data store | ORM context |
+| Auth | Authentication | Auth middleware |
+
+## External Services
+
+| Service | Purpose | SDK |
+|---------|---------|-----|
+| Email provider | Transactional email | `sdk-package` |
+| Analytics | Product analytics | `sdk-package` |
+
+### Service Name
+
+| Location | Purpose |
+|----------|---------|
+| `app/lib/service.ts` | Client initialization |
+| `app/api/webhooks/service.ts` | Webhook handler |
+
+```typescript
+// Usage pattern
+import { client } from "@/lib/service";
+await client.action({ params });
+```
+
+## Integration Checklist
+
+When adding a new integration:
+1. Add environment variable to platform config
+2. Create client wrapper in `app/lib/`
+3. Add to API context if used in routes
+4. Document in this file
+5. Add to environment type definitions
+```
+
+#### security.md — Security Model
+
+```markdown
+---
+title: Security Model
+date: YYYY-MM-DD
+---
+
+# Security Model
+
+## Authentication Flow
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant C as Client
+  participant A as Auth
+  participant D as Database
+  U->>C: Submit credentials
+  C->>A: POST /auth/sign-in
+  A->>D: Verify credentials
+  D-->>A: User record
+  A->>A: Create session
+  A-->>C: Set session cookie
+  C-->>U: Redirect to app
+```
+
+## Authorization Layers
+
+```mermaid
+flowchart TD
+  Request --> L1[Layer 1: Route Protection]
+  L1 --> L2[Layer 2: API Procedures]
+  L2 --> L3[Layer 3: Repository Logic]
+  L3 --> DB[(Database)]
+```
+
+### Layer 1: Route Protection
+Loaders check session before returning data. Unauthenticated users are redirected to login.
+
+### Layer 2: API Procedures
+
+| Procedure | Requirement |
+|-----------|-------------|
+| `publicProcedure` | None |
+| `protectedProcedure` | Valid session |
+| `adminProcedure` | Valid session + admin role |
+
+### Layer 3: Repositories
+Framework-agnostic data access. No auth logic — receives pre-validated user context.
+
+## Role-Based Access Control
+
+```mermaid
+stateDiagram-v2
+  [*] --> User: Sign up
+  User --> Admin: Promote
+  Admin --> User: Demote
+```
+
+| Role | Permissions |
+|------|------------|
+| User | Read/write own resources |
+| Admin | Full access + user management |
+
+## Input Validation
+
+| Layer | Tool | Purpose |
+|-------|------|---------|
+| API | Zod schemas | Request input validation |
+| Database | ORM constraints | Data integrity |
+| Client | Form validation | UX feedback |
+
+## Secrets
+
+| Environment | Storage |
+|-------------|---------|
+| Local | `.dev.vars` or `.env` |
+| Production | Platform secrets manager |
+
+**Rule:** Never use `process.env` if running on edge/serverless. Access env through runtime context.
+```
+
+#### user-journeys.md — User Journeys
+
+```markdown
+---
+title: User Journeys
+date: YYYY-MM-DD
+---
+
+# User Journeys
+
+## Authentication
+
+### Sign Up
+
+```mermaid
+flowchart LR
+  Landing[Landing Page] --> Form[Sign Up Form]
+  Form --> Validate{Valid?}
+  Validate -->|Yes| Create[Create Account]
+  Create --> Dashboard[Dashboard]
+  Validate -->|No| Error[Show Errors]
+  Error --> Form
+```
+
+**Key files:** `app/routes/signup.tsx`, `app/auth/`
+
+### Login
+
+```mermaid
+flowchart LR
+  Login[Login Page] --> Creds[Enter Credentials]
+  Creds --> Auth{Authenticated?}
+  Auth -->|Yes| Dashboard[Dashboard]
+  Auth -->|No| Error[Error Message]
+  Error --> Creds
+```
+
+**Key files:** `app/routes/login.tsx`, `app/auth/`
+
+### Logout
+
+```mermaid
+flowchart LR
+  App[Any Page] --> Logout[Click Logout]
+  Logout --> Clear[Clear Session]
+  Clear --> Landing[Landing Page]
+```
+
+## Core User Journeys
+
+### Primary Flow Name
+
+```mermaid
+flowchart TD
+  Start[Entry Point] --> Step1[Step 1]
+  Step1 --> Step2[Step 2]
+  Step2 --> Decision{Decision?}
+  Decision -->|Path A| ResultA[Outcome A]
+  Decision -->|Path B| ResultB[Outcome B]
+```
+
+**Key files:** `relevant/file/paths`
+
+## Admin Journeys
+
+### User Management
+
+```mermaid
+flowchart LR
+  Admin[Admin Panel] --> Users[User List]
+  Users --> View[View User]
+  View --> Actions{Action}
+  Actions --> Ban[Ban User]
+  Actions --> Promote[Change Role]
+```
+
+**Key files:** `app/routes/admin/`
+
+## Route Access
+
+```mermaid
+flowchart TD
+  Request[Request] --> Auth{Authenticated?}
+  Auth -->|No| Public{Public Route?}
+  Public -->|Yes| Render[Render Page]
+  Public -->|No| Redirect[Redirect to Login]
+  Auth -->|Yes| Admin{Admin Route?}
+  Admin -->|No| Render
+  Admin -->|Yes| IsAdmin{Is Admin?}
+  IsAdmin -->|Yes| Render
+  IsAdmin -->|No| Forbidden[403]
+```
+
+## Error States
+
+```mermaid
+stateDiagram-v2
+  [*] --> Normal
+  Normal --> NetworkError: Connection lost
+  Normal --> AuthError: Session expired
+  Normal --> NotFound: Invalid route
+  Normal --> ServerError: 500
+  NetworkError --> Normal: Retry
+  AuthError --> Login: Redirect
+  NotFound --> Normal: Navigate
+  ServerError --> Normal: Retry
+```
+```
+
+---
+
+## Maintenance Mode
+
+### Adding a Feature Document
+1. Create `docs/features/{feature-name}.md` or `docs/features/{feature-name}-architecture.md`
+2. Use the **Feature Architecture** template below
+3. Add feature summary to `docs/architecture/features.md`
+
+### Adding an Implementation Plan
+1. Create `docs/plans/{feature}-implementation.md`
+2. Use the **Implementation Plan** template below
+
+### Adding Release Notes
+1. Create `docs/releases/YYYY-MM-DD-{title}.md`
+2. Use the **Release Notes** template below
+3. Add changelog entry to `docs/architecture/overview.md`
+
+### Adding a Testing Plan
+1. Create `docs/testing/{feature}/` folder with `screenshots/` subfolder
+2. Add `{feature}.md` testing plan using the **Testing Plan** template
+3. Save screenshots to `screenshots/` subfolder
+
+### Adding Meeting Notes
+1. Create `docs/meetings/YYYY-MM-DD-{description}.md`
+2. Use the **Meeting Notes** template below
+
+### Adding Research
+1. Create `docs/research/{topic}-research.md`
+2. Use the **Research** template below
+
+### Adding a Design Spec
+1. Create `docs/design/{spec-name}.md`
+2. Use the **Design Specification** template below
+
+### Adding a Review
+1. Create `docs/reviews/{review-type}-{subject}.md`
+2. Use the **Review** template below
+
+### Adding a Guide
+1. Create `docs/guides/{topic}-guide.md`
+2. Use the **Guide** template below
+
+### Updating Architecture Context
+When making significant changes, update the relevant `docs/architecture/` file(s):
+- New API routes → `api.md`
+- Schema changes → `data-models.md`
+- New features → `features.md` + `overview.md` changelog
+- New integrations → `integrations.md`
+- Auth/security changes → `security.md`
+- New user flows → `user-journeys.md`
+- Architecture refactor → `system.md` + `overview.md`
+
+---
+
+## Document Templates
+
+### Feature Architecture
+
+```markdown
+---
+title: Feature Name Architecture
+date: YYYY-MM-DD
+---
+
+# Feature Name
+
+## Overview
+
+### Vision
+Brief description of what this feature does and why it exists.
+
+### Core Value Proposition
+What problem does this solve for users?
+
+## User Flow
+
+### Primary Flow
+
+(Include a Mermaid flowchart if applicable)
+
+## System Architecture
+
+### High-Level Architecture
+
+(Include a Mermaid diagram showing component relationships)
+
+## Data Model
+
+### Entity Relationships
+
+(Include ER diagram and/or TypeScript interfaces)
+
+## Feature Breakdown
+
+### Feature 1
+Description, behavior, and edge cases.
+
+### Feature 2
+Description, behavior, and edge cases.
+
+## UI Components
+
+### Component Hierarchy
+Describe the component tree and responsibilities.
+
+## Technical Stack
+
+### API Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/...` | GET | Description |
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `path/to/file` | Description |
+
+## Implementation Checklist
+
+- [ ] Task 1
+- [ ] Task 2
+
+## Future Roadmap
+
+- Potential enhancement 1
+- Potential enhancement 2
+```
+
+### Implementation Plan
+
+```markdown
+---
+title: Feature Name Implementation Plan
+date: YYYY-MM-DD
+---
+
+# Feature Name Implementation
+
+## Status
+In Progress | Completed | Draft
+
+## Overview
+What this plan covers and the goals.
+
+## Phases
+
+### Phase 1: Foundation
+- [ ] Task 1
+- [ ] Task 2
+
+### Phase 2: Core Features
+- [ ] Task 1
+- [ ] Task 2
+
+### Phase 3: Polish
+- [ ] Task 1
+- [ ] Task 2
+
+## Files Created/Modified
+
+| File | Change |
+|------|--------|
+| `path/to/file` | Description |
+
+## Validation Checklist
+
+- [ ] All tests passing
+- [ ] Build succeeds
+- [ ] Feature works end-to-end
+```
+
+### Release Notes
+
+```markdown
+---
+title: Release Title
+date: YYYY-MM-DD
+---
+
+# Release Title
+
+## Summary
+Brief overview of what changed.
+
+## New Features
+- Feature 1: description
+- Feature 2: description
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `path/to/file` | What it does |
+
+## Bug Fixes
+- Fix 1: description
+
+## Breaking Changes
+None.
+
+## Dependencies Added
+None.
+```
+
+### Testing Plan
+
+```markdown
+---
+title: Testing Plan - Feature Name
+date: YYYY-MM-DD
+---
+
+# Testing Plan: Feature Name
+
+## Overview
+What was implemented and needs testing.
+
+## Prerequisites
+- [ ] Dev server running
+- [ ] Test data available
+
+## Test Scenarios
+
+### Scenario 1: Happy Path
+**Steps:**
+1. Navigate to URL
+2. Perform action
+3. Verify result
+
+**Expected:** Describe expected outcome
+
+**Screenshot:** ![Description](./screenshots/scenario-1.png)
+
+### Scenario 2: Edge Case
+**Steps:**
+1. Step 1
+2. Step 2
+
+**Expected:** Describe expected outcome
+
+## UI Elements to Verify
+
+| Element | Expected State |
+|---------|---------------|
+| Button | Enabled, correct label |
+
+## Test IDs Reference
+
+| Element | Test ID |
+|---------|---------|
+| Submit button | `data-testid="submit-btn"` |
+
+## Issues Found
+
+| # | Description | Severity | Status |
+|---|-------------|----------|--------|
+| 1 | Description | High/Med/Low | Open/Fixed |
+
+## Next Steps
+- [ ] Action item 1
+- [ ] Action item 2
+```
+
+### Meeting Notes
+
+```markdown
+---
+title: Meeting Title
+date: YYYY-MM-DD
+---
+
+# Meeting Title
+
+**Date:** YYYY-MM-DD
+**Attendees:** Names
+
+## Agenda
+1. Topic 1
+2. Topic 2
+
+## Discussion
+
+### Topic 1
+Key points discussed.
+
+### Topic 2
+Key points discussed.
+
+## Action Items
+- [ ] @person - Task description (due date)
+
+## Next Meeting
+Date and planned topics.
+```
+
+### Research
+
+```markdown
+---
+title: Topic Research
+date: YYYY-MM-DD
+---
+
+# Topic Research
+
+## Executive Summary
+Brief summary of findings and recommendations.
+
+## Research Objectives
+What questions this research aims to answer.
+
+## Methodology
+How the research was conducted (competitor analysis, user interviews, etc.)
+
+## Findings
+
+### Finding 1: Title
+Analysis and evidence.
+
+### Finding 2: Title
+Analysis and evidence.
+
+## Competitor Analysis
+
+| Competitor | Strength | Weakness | Relevance |
+|------------|----------|----------|-----------|
+| Name | Detail | Detail | High/Med/Low |
+
+## Key Takeaways
+1. Takeaway 1
+2. Takeaway 2
+
+## Recommendations
+1. Recommendation with rationale
+2. Recommendation with rationale
+
+## Sources
+- Source 1
+- Source 2
+```
+
+### Design Specification
+
+```markdown
+---
+title: Design Spec Name
+date: YYYY-MM-DD
+---
+
+# Design Spec Name
+
+## Summary
+One paragraph describing the design direction.
+
+## Research Sources
+- Reference 1
+- Reference 2
+
+## Core Principles
+1. Principle 1: description
+2. Principle 2: description
+
+## Visual Language
+
+### Typography
+Font choices, scale, and hierarchy.
+
+### Color Palette
+Primary, secondary, accent, and semantic colors.
+
+### Spacing & Layout
+Grid system, spacing scale, and layout patterns.
+
+### Motion & Interaction
+Animation principles, transitions, and interaction patterns.
+
+## Component Specifications
+
+### Component 1
+Visual spec, states, and behavior.
+
+### Component 2
+Visual spec, states, and behavior.
+
+## Do's and Don'ts
+
+### Do
+- Guidance 1
+- Guidance 2
+
+### Don't
+- Anti-pattern 1
+- Anti-pattern 2
+
+## References
+- Industry examples and inspiration
+```
+
+### Review
+
+```markdown
+---
+title: Review Type - Subject
+date: YYYY-MM-DD
+---
+
+# Review: Subject
+
+## Plan Alignment
+
+| Requirement | Status | Notes |
+|-------------|--------|-------|
+| Requirement 1 | Met / Partial / Not Met | Details |
+
+## Implementation Quality
+
+### Architecture
+Assessment of architectural decisions.
+
+### Code Quality
+Assessment of code patterns, DRY, naming.
+
+### Performance
+Assessment of performance implications.
+
+### Security
+Assessment of security considerations.
+
+## Recommendations
+
+### Must Fix (Blockers)
+1. Issue and remediation
+
+### Should Improve
+1. Improvement suggestion
+
+### Nice to Have
+1. Enhancement idea
+
+## Summary
+Overall assessment and verdict.
+```
+
+### Guide
+
+```markdown
+---
+title: Topic Guide
+date: YYYY-MM-DD
+---
+
+# Topic Guide
+
+## Executive Summary
+What this guide covers and who it's for.
+
+## Background
+Context needed to understand the guide.
+
+## Step-by-Step
+
+### Step 1: Title
+Detailed instructions with code examples.
+
+### Step 2: Title
+Detailed instructions with code examples.
+
+### Step 3: Title
+Detailed instructions with code examples.
+
+## Lessons Learned
+Key insights from the implementation.
+
+## Replication Instructions
+How to apply this pattern to a new feature/project.
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| Issue 1 | Fix 1 |
+
+## References
+- Related docs and resources
+```
+
+---
+
+## Formatting Standards
+
+1. Use **H1** for the main title, **H2** for sections, **H3** for subsections
+2. Include **Mermaid diagrams** for complex flows and architecture — lead with visuals, not prose
+3. Use **tables** for structured data (file lists, comparisons, checklists)
+4. Use `- [ ]` for action items and checklists
+5. Always specify language in fenced code blocks
+6. Link to related docs within the same `docs/` tree
+7. Keep prose minimal — 1-3 sentences per section, then use diagrams/tables
+
+## Document Lifecycle
+
+Features typically flow through this documentation chain:
+
+```
+research/ --> design/ --> features/ --> plans/ --> (implementation) --> reviews/ --> testing/ --> releases/
+     \                                                                                          /
+      `----------------------------> architecture/ (updated continuously) <--------------------'
+```
+
+- **Research** informs design decisions
+- **Design specs** guide feature architecture
+- **Feature docs** define what to build
+- **Plans** break work into phases
+- **Reviews** validate against plans
+- **Testing plans** verify the implementation
+- **Release notes** summarize what shipped
+- **Guides** capture reusable lessons
+- **Architecture** is the living system-of-record, updated at every stage

--- a/cf-saas-stack/commands/dry-audit.md
+++ b/cf-saas-stack/commands/dry-audit.md
@@ -1,0 +1,317 @@
+---
+description: Audits the codebase for DRY violations and enforces folder structure conventions
+argument-hint: [target area or "full" for complete audit]
+allowed-tools: Read, Glob, Grep, Bash, Edit, Write
+---
+
+# DRY Audit & Folder Structure Enforcer
+
+Audits the codebase for DRY violations and enforces folder structure conventions. Identifies duplicated schemas, repeated UI patterns, redundant repository logic, and inconsistent organization.
+
+Audit target: $ARGUMENTS
+
+## When to Run
+
+- Before creating new schemas, components, repositories, or workflows
+- After implementing a new feature (to catch newly introduced duplication)
+- When the user asks to clean up, refactor, or audit code quality
+
+## Audit Workflow
+
+```
+Task Progress:
+- [ ] Step 1: Check folder structure compliance
+- [ ] Step 2: Scan schemas for shared field opportunities
+- [ ] Step 3: Scan UI components for repeated patterns
+- [ ] Step 4: Scan repositories for CRUD duplication
+- [ ] Step 5: Scan workflows for shared logic
+- [ ] Step 6: Report findings and suggest extractions
+```
+
+---
+
+## Step 1: Folder Structure Conventions
+
+Verify new files follow these conventions. If a file is in the wrong place, flag it.
+
+### Required structure
+
+```
+app/
+  models/              # Zod schemas grouped by domain
+    research/          #   domain subfolder
+      schema.ts        #   main schemas
+      common.ts        #   shared base schemas (extract here)
+  repositories/        # One file per entity, pure DB functions
+  trpc/routes/         # One router per domain
+  routes/platform/
+    components/
+      <feature>/       # Feature-specific components
+        common/        #   Shared UI within the feature
+        results/       #   Result display components
+        empty-state/   #   Empty state components
+      shared/          # Cross-feature shared components
+  lib/
+    constants/         # Or constants.ts — centralized config values
+    prompts/           # AI prompts grouped by domain subfolder
+    utils.ts           # Generic pure helpers
+  components/          # Global reusable UI (shadcn + custom)
+workflows/             # One WorkflowEntrypoint per file
+```
+
+### Naming conventions
+
+| Layer | Pattern | Example |
+|-------|---------|---------|
+| Repository functions | `getById`, `list`, `create`, `update`, `delete` | `getResearchById(db, { id })` |
+| tRPC routes | domain-named router | `research.ts` exports `researchRouter` |
+| Schemas | `PascalCaseSchema` | `ExecutiveSummarySchema` |
+| Components | PascalCase file + export | `StatusBadge.tsx` |
+| Workflows | `kebab-case.ts`, class `PascalCaseWorkflow` | `discovery-agent-gemini.ts` / `DiscoveryAgentGeminiWorkflow` |
+| Prompts | `<domain>/` subfolder with descriptive files | `prompts/discovery-agent/system.ts` |
+
+---
+
+## Step 2: Schema DRY Checks
+
+Search `app/models/` for these known shared patterns. If a new schema duplicates any of them, extract to `app/models/research/common.ts` (or the appropriate domain common file).
+
+### Patterns to extract
+
+**Base workflow payload** — shared across discovery-agent, internal-discovery, product-discovery:
+```typescript
+// app/models/research/common.ts
+export const BaseWorkflowPayloadSchema = z.object({
+  researchId: z.string(),
+  productName: z.string(),
+  description: z.string(),
+  targetMarket: z.string().optional(),
+  website: z.string().optional(),
+  clientVision: z.string().optional(),
+  transcript: z.string().optional(),
+  documents: z.array(z.string()).optional(),
+});
+```
+
+**Base executive summary** — shared `context`, `keyFindings`, `topOpportunities`, `recommendedFocus`:
+```typescript
+export const BaseExecutiveSummarySchema = z.object({
+  context: z.string(),
+  keyFindings: z.array(z.string()),
+  topOpportunities: z.array(z.string()),
+  recommendedFocus: z.string(),
+});
+```
+
+**Base risk schema** — shared `assumptions`, `deliveryRisks`, `adoptionRisks` with `severity` enum:
+```typescript
+const SeverityEnum = z.enum(["low", "medium", "high", "critical"]);
+
+export const BaseRiskItemSchema = z.object({
+  risk: z.string(),
+  severity: SeverityEnum,
+  mitigation: z.string(),
+});
+
+export const BaseRisksSchema = z.object({
+  assumptions: z.array(z.string()),
+  deliveryRisks: z.array(BaseRiskItemSchema),
+  adoptionRisks: z.array(BaseRiskItemSchema),
+});
+```
+
+**Base opportunity map** — shared `keyOpportunities`, `prioritizationFramework`, `quickWins`, `bigBets`:
+```typescript
+export const BaseOpportunityMapSchema = z.object({
+  keyOpportunities: z.array(z.object({
+    title: z.string(),
+    description: z.string(),
+    impact: z.enum(["low", "medium", "high"]),
+    effort: z.enum(["low", "medium", "high"]),
+  })),
+  quickWins: z.array(z.string()),
+  bigBets: z.array(z.string()),
+});
+```
+
+**How to check**: Search for `z.object` definitions containing `keyFindings`, `deliveryRisks`, `quickWins`, or `severity` across `app/models/`. If found in more than one file, extract to common.
+
+**How to extend**: Use `.extend()` or `.merge()`:
+```typescript
+const DiscoveryExecutiveSummarySchema = BaseExecutiveSummarySchema.extend({
+  strategicImplications: z.array(z.string()),
+});
+```
+
+---
+
+## Step 3: UI Component DRY Checks
+
+Search `app/routes/` and `app/components/` for these repeated patterns. If found duplicated, extract or reuse.
+
+### Loading spinner
+**Search**: `animate-spin` + `IconLoader2` or `Loader2`
+**Reuse**: Should be a single `<LoadingSpinner />` in `app/components/shared/` or `app/components/ui/`
+```typescript
+// Expected: import { LoadingSpinner } from "@/components/ui/loading-spinner"
+<LoadingSpinner size="md" className="text-muted-foreground" />
+```
+
+### Error/failed state
+**Search**: `IconAlertTriangle` + `"failed"` or `"error"` in JSX
+**Reuse**: Should be a single `<ErrorState />` component
+```typescript
+<ErrorState
+  title="Analysis Failed"
+  message={errorMessage}
+  onRetry={handleRetry}
+/>
+```
+
+### Empty state
+**Search**: Components named `*empty-state*` or containing "No items" / "Get started" patterns
+**Reuse**: Consider a base `<EmptyState />` with variants
+
+### Status badges
+**Search**: Status config objects mapping status strings to `{ label, color, icon }`
+**Reuse**: Single `<StatusBadge status={status} variant="research" />` component
+
+### Source citations
+**Search**: Tooltip-wrapped citation badges with `[n]` patterns
+**Reuse**: Already exists at `market-research/common/source-citations.tsx` — use it, don't duplicate
+
+---
+
+## Step 4: Repository DRY Checks
+
+Search `app/repositories/` for these patterns.
+
+### Pagination
+**Search**: `Math.ceil` + `offset` + `totalPages` pattern
+**Reuse**: Extract to `app/lib/repository-utils.ts`:
+```typescript
+export interface PaginatedResult<T> {
+  items: T[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export function buildPaginatedResult<T>(
+  items: T[],
+  total: number,
+  page: number,
+  limit: number
+): PaginatedResult<T> {
+  return { items, total, page, limit, totalPages: Math.ceil(total / limit) };
+}
+```
+
+### Organization access check
+**Search**: `organizationId !== ` comparison patterns
+**Reuse**: Extract to a shared helper:
+```typescript
+export function verifyOrgAccess(resourceOrgId: string, userOrgId: string): void {
+  if (resourceOrgId !== userOrgId) {
+    throw new ForbiddenError("Access denied");
+  }
+}
+```
+
+### AI service availability check
+**Search**: `throw new TRPCError` + `"AI service not configured"`
+**Reuse**: Extract to `app/lib/ai-utils.ts`:
+```typescript
+export function requireAIService<T>(service: T | null, name: string): asserts service is T {
+  if (!service) {
+    throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: `${name} not configured` });
+  }
+}
+```
+
+### JSON parsing from AI responses
+**Search**: Regex extracting JSON from markdown code blocks (triple backtick patterns)
+**Reuse**: Single `parseAIJsonResponse()` utility
+
+---
+
+## Step 5: Workflow DRY Checks
+
+Search `workflows/` for these patterns.
+
+### Step name constants
+**Search**: `STEP_NAMES` or similar step-number-to-name maps
+**Reuse**: If step names overlap between workflows, extract shared ones
+
+### Progress update wrapper
+**Search**: `updateResearchProgress` calls inside `step.do()`
+**Reuse**: Wrapper function:
+```typescript
+export async function trackedStep<T>(
+  step: WorkflowStep,
+  db: Database,
+  researchId: string,
+  stepNumber: number,
+  stepName: string,
+  totalSteps: number,
+  fn: () => Promise<T>
+): Promise<T>
+```
+
+### Source index mapping
+**Search**: Functions transforming `sourceIndices: number[]` to `sources: SourceReference[]`
+**Reuse**: Single utility in `app/lib/source-utils.ts`
+
+---
+
+## Step 6: Report Format
+
+After auditing, output findings in this format:
+
+```markdown
+## DRY Audit Results
+
+### Folder Structure
+- [PASS/FAIL] New files follow conventions
+- [WARN] <file> should be in <expected location>
+
+### Schema Duplication
+- [DRY] <field pattern> duplicated in <file1>, <file2>
+  → Extract to: <target file> using <BaseSchema>.extend()
+
+### UI Duplication
+- [DRY] Loading spinner reimplemented in <file>
+  → Reuse: <shared component path>
+
+### Repository Duplication
+- [DRY] Pagination logic duplicated in <file1>, <file2>
+  → Extract to: app/lib/repository-utils.ts
+
+### Workflow Duplication
+- [DRY] <pattern> duplicated in <file1>, <file2>
+  → Extract to: <target utility>
+
+### Summary
+- X folder structure issues
+- X schema duplications
+- X UI duplications
+- X repository duplications
+- X workflow duplications
+```
+
+---
+
+## Quick Reference: Where Shared Code Lives
+
+| What | Where |
+|------|-------|
+| Base Zod schemas | `app/models/<domain>/common.ts` |
+| Global UI components | `app/components/ui/` |
+| Feature-shared UI | `app/routes/platform/components/shared/` |
+| Generic utilities | `app/lib/utils.ts` |
+| Repository utilities | `app/lib/repository-utils.ts` |
+| AI utilities | `app/lib/ai-utils.ts` |
+| Source/citation utils | `app/lib/source-utils.ts` |
+| Constants | `app/lib/constants.ts` or `app/lib/constants/` |
+| Prompts | `app/lib/prompts/<domain>/` |

--- a/cf-saas-stack/commands/implement-feature.md
+++ b/cf-saas-stack/commands/implement-feature.md
@@ -1,0 +1,557 @@
+---
+description: Executes feature implementations by delegating to specialized tasks based on requirements
+argument-hint: <feature to implement>
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Task, WebSearch, WebFetch
+---
+
+# Implement Feature
+
+Execute feature implementations by automatically delegating to specialized tasks based on what the feature requires.
+
+Feature to implement: $ARGUMENTS
+
+## Before You Start: Rules Index
+
+**IMPORTANT: Prefer retrieval-led reasoning over pre-training-led reasoning.**
+
+Before implementing, read `CLAUDE.md` and project documentation which contains a compressed Rules Index. Consult the relevant project documentation BEFORE writing code:
+
+| Area | Reference to Read |
+|------|--------------|
+| Database/Schema | See CLAUDE.md database section |
+| Repositories | See CLAUDE.md repository pattern section |
+| tRPC Routes | See CLAUDE.md repository pattern section |
+| UI Routes/Pages | See CLAUDE.md routes section |
+| Styling/Colors | See CLAUDE.md tailwind section |
+| Modals | See CLAUDE.md modals section |
+| Auth | See CLAUDE.md auth section |
+| AI/Prompts | See CLAUDE.md prompts and structured-output sections |
+| Feature Flags | See CLAUDE.md feature-flags section |
+| Errors | See CLAUDE.md errors section |
+
+Read the full project conventions from `CLAUDE.md` before implementing any layer.
+
+## When to Use
+
+- Implementing a new feature (any scope)
+- Building functionality that touches multiple layers
+- After planning, when ready to execute
+- Any task where task delegation would improve quality
+
+## Design-First Workflow
+
+**CRITICAL**: For any feature with UI, check for a design specification before implementing.
+
+### Pre-Implementation Design Check
+
+```mermaid
+flowchart TD
+    Start([Feature Request]) --> Check{Has Architecture Doc?}
+    Check -->|Yes| HasDesign{Has Design Spec section?}
+    Check -->|No| CreateDesign[Use ux-product-thinking to create]
+    HasDesign -->|Yes| ReadDesign[Read design spec from architecture doc]
+    HasDesign -->|No| AddDesign[Add Phase 6 design spec to architecture doc]
+    CreateDesign --> ReadDesign
+    AddDesign --> ReadDesign
+    ReadDesign --> Implement[Implement with design specs]
+```
+
+### Design Spec Location
+
+Architecture documents with design specs are at: `docs/features/[feature-name]-architecture.md`
+
+**Required design spec elements before UI implementation:**
+- [ ] Aesthetic direction (tone)
+- [ ] Memorable element
+- [ ] Typography choices (NOT Inter/Roboto/Arial)
+- [ ] Color palette with CSS variable mappings
+- [ ] Motion/animation moments
+- [ ] Spatial composition approach
+
+### When to Invoke ux-product-thinking First
+
+| Scenario | Action |
+|----------|--------|
+| New feature with UI | Run /ux-product-thinking first to create architecture doc with design spec |
+| Existing architecture doc missing design spec | Add Phase 6 design spec before implementing |
+| Architecture doc has design spec | Read and follow during implementation |
+| Backend-only feature | Skip design spec, proceed with implementation |
+
+## Workflow
+
+### Step 1: Analyze Feature Scope
+
+Determine what the feature requires:
+
+| Scope | Indicators | Layers Affected |
+|-------|------------|-----------------|
+| **Full-stack** | New data model, CRUD operations | DB → Repository → tRPC → UI |
+| **Backend** | API changes, business logic | Repository → tRPC |
+| **Frontend** | UI changes, components | Components → Routes |
+| **Integration** | External services, webhooks | Repository → tRPC → possibly UI |
+
+### Step 2: Map to Task Execution Order
+
+Execute tasks in dependency order:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    DESIGN PHASE (if UI feature)             │
+├─────────────────────────────────────────────────────────────┤
+│  0. Design Specification (ux-product-thinking)              │
+│     └─ Research → Goals → Flows → Components → Design Spec  │
+│     └─ Creates: docs/features/[feature]-architecture.md     │
+│     └─ Output: Typography, colors, motion, composition      │
+├─────────────────────────────────────────────────────────────┤
+│                    IMPLEMENTATION PHASE                      │
+├─────────────────────────────────────────────────────────────┤
+│  1. Core Implementation                                     │
+│     └─ Schema → Repository → tRPC → Components → Routes     │
+│     └─ READ design spec from architecture doc FIRST         │
+│     └─ Apply distinctive typography, colors, motion         │
+│                                                              │
+│  2. Figma Integration (if applicable)                       │
+│     └─ Convert Figma code to use project CSS variables      │
+│                                                              │
+│  3. Logging - Add structured debug logs                     │
+│                                                              │
+│  3.5 DRY Audit (dry-audit) - Check for duplications        │
+│      └─ Schemas, UI components, repository logic, workflows │
+│      └─ Run: /dry-audit                                     │
+├─────────────────────────────────────────────────────────────┤
+│                    VALIDATION PHASE                          │
+├─────────────────────────────────────────────────────────────┤
+│  4. Testing                                                  │
+│     └─ Browser verification → E2E tests → Documentation     │
+│                                                              │
+│  5. Analytics - if schema has metrics                        │
+│                                                              │
+│  6. Principal Review (/principal-review)                     │
+│     └─ Plan alignment + implementation quality              │
+├─────────────────────────────────────────────────────────────┤
+│                    DOCUMENTATION PHASE                       │
+├─────────────────────────────────────────────────────────────┤
+│  7. Context Update                                           │
+│     └─ Update project documentation with new feature        │
+│                                                              │
+│  8. Architecture Update (/architecture-tracker)              │
+│     └─ Update high-level-architecture.md with routes/flows  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Step 3: Execute with Delegation
+
+For each phase, use the Task tool to delegate work:
+
+```
+Task: Brief description of what needs to be done
+Context: Detailed instructions including project context
+```
+
+---
+
+## Task Delegation Guide
+
+### Design Specification: `/ux-product-thinking` + `/frontend-design`
+
+**When:** Any feature with UI that doesn't have a design spec
+
+**Triggers:**
+- No architecture doc exists at `docs/features/[feature]-architecture.md`
+- Architecture doc exists but lacks Frontend Design Specification section
+- User requests distinctive/memorable UI
+
+**Delegation Pattern:**
+```markdown
+1. Use /ux-product-thinking to create architecture doc with:
+   - Research, goals, user analysis, flows, components, wireframes
+   - Phase 6: Frontend Design Specification
+
+2. Read and apply the /frontend-design guidelines
+   for the design spec section
+
+Output: `docs/features/{feature}-architecture.md` with complete design spec (include YAML frontmatter: `title`, `date: YYYY-MM-DD` with **current date** for `/admin/docs` sorting)
+```
+
+**Applying Design Spec During Implementation:**
+```markdown
+Before implementing {feature} UI:
+
+1. Read design spec from `docs/features/{feature}-architecture.md`
+2. Read /frontend-design guidelines for implementation guidance
+3. Apply: typography, colors (CSS variables), motion, composition
+```
+
+---
+
+### Core Implementation
+
+**When:** Always (main implementation work)
+
+**Delegation Pattern:**
+```markdown
+Implement {feature} following the project's architecture:
+
+**Repository Layer** (`app/repositories/{name}.ts`):
+- Define `type Database = Context["db"];`
+- Export pure functions with signature `async function name(db: Database, input: InputInterface)`
+- Wrap operations in try-catch, throw custom errors from `@/models/errors`
+
+**tRPC Routes** (`app/trpc/routes/{name}.ts`):
+- Import repository as `import * as {name}Repository from "@/repositories/{name}";`
+- Use Zod for input validation
+- Use appropriate procedure type (publicProcedure, protectedProcedure, adminProcedure)
+
+**UI Components/Routes**:
+- Use `context.trpc` in loaders
+- Use `api.{route}.{method}.useQuery/useMutation` in components
+```
+
+### Figma Conversion
+
+**When:** Receiving code from Figma with hardcoded colors
+
+**Triggers:**
+- Hex values like `bg-[#003362]`
+- Tailwind default palette (`bg-blue-600`, `text-gray-900`)
+- RGB/OKLCH values
+
+**Delegation Pattern:**
+```markdown
+Convert this Figma output to use project CSS variables:
+
+{paste code}
+
+Convert following priority:
+1. Semantic colors (bg-background, text-foreground, bg-primary)
+2. Text hierarchy (text-text-heading, text-muted-foreground)
+3. Brand palette (bg-brand-500) if semantic doesn't fit
+```
+
+### Design Validation
+
+**When:** After implementing any UI from Figma designs
+
+**Delegation Pattern:**
+```markdown
+Validate the implementation at {route} against the Figma design.
+
+1. Extract design specs from the Figma design
+2. Navigate to implementation using Bash with playwright
+3. Compare: layout, typography, colors, spacing
+4. Document any discrepancies
+5. Flag if hardcoded colors found (should use CSS variables)
+```
+
+### Logging
+
+**When:** After implementing features with business logic
+
+**Delegation Pattern:**
+```markdown
+Add structured logging to the new {feature} implementation:
+
+Files to add logging:
+- `app/repositories/{name}.ts` - Use `loggers.repository`
+- `app/trpc/routes/{name}.ts` - Use `loggers.trpc`
+- `app/routes/{path}.tsx` - Use `createRequestLogger("loader")`
+
+Add logs for:
+- Entry/exit points with timing
+- State changes (before/after)
+- Errors with context
+- Authentication checks
+```
+
+### Testing
+
+**When:** After core implementation is complete
+
+**CRITICAL: SCREENSHOTS ARE MANDATORY**
+
+**Testing is NOT complete without screenshots. The testing task MUST:**
+1. Take screenshots with Bash using playwright for each scenario
+2. Save screenshots to the workspace (not just temp folder)
+3. Embed screenshots in test documentation
+4. Copy screenshots to public folder for docs viewer
+
+**Delegation Pattern:**
+```markdown
+Test the {feature} implementation:
+
+1. Create testing plan at `docs/testing/{feature}/{feature}.md` (include YAML frontmatter: `title`, `date: YYYY-MM-DD` with **current date** so the doc sorts correctly in `/admin/docs`)
+2. Create screenshots folder at `docs/testing/{feature}/screenshots/`
+3. Verify with Bash using playwright:
+   - Navigate to {route}
+   - Test happy path: {steps}
+   - **TAKE SCREENSHOT after each major state**
+   - Test edge cases: {cases}
+   - **TAKE SCREENSHOT for edge cases**
+   - Test error handling: {scenarios}
+   - **TAKE SCREENSHOT for error states**
+4. **MANDATORY: Save screenshots to `docs/testing/{feature}/screenshots/`**
+5. **MANDATORY: Copy screenshots to `public/docs/testing/{feature}/screenshots/`**
+6. **MANDATORY: Embed screenshots in test documentation with markdown image links**
+5. Write E2E tests at `e2e/{feature}.spec.ts`
+6. Add data-testid attributes to interactive elements
+```
+
+### Principal Review: `/principal-review`
+
+**When:** After implementation and testing are complete, before final documentation.
+
+**Delegation Pattern:**
+```markdown
+Run /principal-review for {feature}:
+
+1. Plan/spec: docs/plans/{feature}-implementation.md or docs/features/{feature}-architecture.md
+2. Implementation: {list changed files or branch diff}
+3. Output: Plan alignment table + implementation quality table + recommendations + verdict
+```
+
+Read the /principal-review command for the full workflow and report template.
+
+---
+
+### Analytics
+
+**When:** Schema includes timestamp, enum, or boolean fields worth tracking
+
+**Triggers:**
+- New `createdAt` fields → time-series growth charts
+- New enum fields → distribution charts
+- New boolean fields → conversion metrics
+
+**Delegation Pattern:**
+```markdown
+Create analytics for the new {table/feature}:
+
+Schema fields to analyze:
+- {field}: {type} → {chart type}
+
+Create:
+1. Repository functions in `app/repositories/analytics.ts`
+2. tRPC routes in `app/trpc/routes/analytics.ts`
+3. Dashboard components using `@/components/analytics`
+```
+
+### DRY Audit: `/dry-audit`
+
+**When:** After core implementation, before testing
+
+**Triggers:**
+- New schemas added to `app/models/`
+- New UI components created
+- New repository functions added
+- New workflows created
+
+**How to use:**
+Run /dry-audit and follow the 6-step audit:
+1. Verify new files follow folder structure conventions
+2. Check schemas for shared field patterns (extract to `common.ts`)
+3. Check UI for duplicated loading/error/empty states (reuse shared components)
+4. Check repositories for duplicated pagination/filtering logic
+5. Check workflows for duplicated step logic
+6. Report findings and refactor before proceeding
+
+**Key principle:** Before creating new code, search for existing shared utilities first. See the "Quick Reference: Where Shared Code Lives" table in /dry-audit.
+
+---
+
+### Documentation
+
+**When:** Always (after implementation complete)
+
+**Delegation Pattern:**
+```markdown
+Update project documentation with the new {feature}:
+
+Add to Features section:
+- What it does
+- Key files involved
+- Important implementation details
+
+Update Recent Changes with brief summary.
+
+If applicable, add Mermaid diagrams for:
+- Data flow
+- User flows
+- Schema relationships
+```
+
+### Architecture Updates: `/architecture-tracker`
+
+**When:** After features that add routes, tables, or change flows
+
+**Triggers:**
+- New routes added to `app/routes.ts`
+- New database tables created
+- New feature flows implemented
+- Architectural decisions made
+
+**Delegation Pattern:**
+```markdown
+Update high-level architecture document for {feature}:
+
+Changes made:
+- New routes: {list routes}
+- New tables: {list tables}
+- New features: {describe}
+
+Update:
+1. Route Map diagram with new routes
+2. Information Architecture table
+3. Feature Flows section (add new flow diagram)
+4. Data Relationships (if new tables)
+5. Changelog with dated entry
+```
+
+---
+
+## Execution Decision Tree
+
+```
+Does this feature have a UI component?
+├─ Yes → Does architecture doc exist with design spec?
+│        ├─ No → 0. Use /ux-product-thinking FIRST
+│        │       └─ Create docs/features/[feature]-architecture.md
+│        │       └─ Include Phase 6 Frontend Design Spec
+│        │
+│        └─ Yes → Read design spec, then:
+│                 Is this from Figma?
+│                 ├─ Yes → 1. Implement (following design spec)
+│                 │        2. Convert Figma colors to CSS variables
+│                 │        3. Validate design match
+│                 │        4. Test
+│                 │        5. /principal-review
+│                 │        6. Update docs
+│                 │
+│                 └─ No → 1. Implement (following design spec)
+│                         2. Add logging (if business logic)
+│                         3. /dry-audit (check for duplications)
+│                         4. Test
+│                         5. /principal-review
+│                         6. Update docs
+│
+└─ No (backend only) → Does it involve database/API changes?
+        ├─ Yes → 1. Implement (full-stack)
+        │        2. Add logging
+        │        3. /dry-audit (check for duplications)
+        │        4. Test
+        │        5. Analytics (if new metrics)
+        │        6. /principal-review
+        │        7. Update docs
+        │
+        └─ No → 1. Implement
+                2. /dry-audit (check for duplications)
+                3. Test
+                4. /principal-review
+                5. Update docs
+```
+
+---
+
+## Quick Reference
+
+| Skill/Task | Trigger | Output |
+|----------------|---------|--------|
+| `/ux-product-thinking` | UI feature without architecture doc | Architecture doc with flows + design spec |
+| `/frontend-design` | UI implementation (read during Phase 6 & implementation) | Design guidelines |
+| Core implementation | Always | Core implementation |
+| Figma conversion | Figma code with hardcoded colors | Converted code |
+| Design validation | After Figma implementation | Validation report |
+| Logging | Features with business logic | Structured logs |
+| `/dry-audit` | After implementation (new schemas/components/repos) | DRY compliance report |
+| Testing | After implementation | Tests + documentation |
+| Analytics | New trackable data | Dashboard |
+| `/principal-review` | After implementation | Plan alignment + implementation quality report |
+| Documentation update | Always (after implementation) | Updated project docs |
+| `/architecture-tracker` | After route/schema changes | Updated architecture doc |
+
+---
+
+## Example Execution
+
+### Full-Stack Feature: User Preferences
+
+```markdown
+**Feature:** Add user preferences with theme and notification settings
+
+**Scope Analysis:** Full-stack (new table, CRUD, settings page)
+
+**Execution:**
+
+1. **Core Implementation** → Implement schema, repository, tRPC, UI
+2. **Logging** → Add logging to repository and tRPC
+3. **/dry-audit** → Check new schema/repo/components for DRY violations
+4. **Testing** → Verify settings page, write e2e tests
+5. **Analytics** → Skip (no meaningful metrics for preferences)
+6. **/principal-review** → Run plan alignment + implementation quality
+7. **Documentation** → Document new feature in project docs
+```
+
+### Frontend Feature from Figma
+
+```markdown
+**Feature:** Implement dashboard card design from Figma
+
+**Scope Analysis:** Frontend (component from design)
+
+**Execution:**
+
+1. **Core Implementation** → Build component structure
+2. **Figma Conversion** → Convert colors to CSS variables
+3. **Design Validation** → Verify implementation matches design
+4. **Testing** → Visual verification, screenshot documentation
+5. **Documentation** → Document new component
+```
+
+### Design-First Feature: Landing Page
+
+```markdown
+**Feature:** Create landing page for new product launch
+
+**Scope Analysis:** Frontend with UI (needs design spec first)
+
+**Pre-check:** No architecture doc exists → Use /ux-product-thinking first
+
+**Execution:**
+
+0. **/ux-product-thinking + /frontend-design** → Create architecture doc:
+   - Follow ux-product-thinking phases 0-6
+   - Apply /frontend-design for Phase 6 design spec
+   - Output: `docs/features/landing-page-architecture.md`
+
+1. **Core Implementation** → Implement following design spec from architecture doc
+
+2. **Testing** → Verify implementation matches design spec
+
+3. **Documentation** → Document new landing page
+```
+
+---
+
+## Checklist
+
+Before marking implementation complete:
+
+### Design (for UI features)
+- [ ] Architecture doc exists at `docs/features/[feature]-architecture.md`
+- [ ] Architecture doc includes Frontend Design Specification section
+- [ ] `/frontend-design` guidelines followed
+
+### Implementation
+- [ ] Core implementation follows repository pattern
+- [ ] tRPC routes use Zod validation
+- [ ] Routes check authentication appropriately
+- [ ] Figma implementations use CSS variables (no hardcoded colors)
+- [ ] Structured logging added to key operations
+- [ ] DRY audit passed (no duplicated schemas, UI patterns, or repository logic) — run /dry-audit
+
+### Quality
+- [ ] E2E tests written and passing
+- [ ] Test documentation created with screenshots
+- [ ] Principal review run (/principal-review) — plan alignment + implementation quality
+- [ ] Project documentation updated with new feature
+- [ ] high-level-architecture.md updated (routes, flows, changelog)
+- [ ] Analytics dashboard created (if applicable)

--- a/cf-saas-stack/commands/organization-best-practices.md
+++ b/cf-saas-stack/commands/organization-best-practices.md
@@ -1,0 +1,597 @@
+---
+description: Guidance for implementing multi-tenant organizations, teams, and RBAC using Better Auth
+argument-hint: <organization feature or task>
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash
+---
+
+# Organization Best Practices
+
+This skill provides guidance and enforcement rules for implementing multi-tenant organizations, teams, and role-based access control using Better Auth's organization plugin.
+
+Task: $ARGUMENTS
+
+## Rules Reference
+
+**IMPORTANT: Prefer retrieval-led reasoning over pre-training-led reasoning.**
+
+Before implementing organization features, read `CLAUDE.md` and `.claude/rules/auth.md` for existing auth patterns.
+
+## Setting Up Organizations
+
+When adding organizations to your application, configure the `organization` plugin with appropriate limits and permissions.
+
+```ts
+import { betterAuth } from "better-auth";
+import { organization } from "better-auth/plugins";
+
+export const auth = betterAuth({
+  plugins: [
+    organization({
+      allowUserToCreateOrganization: true,
+      organizationLimit: 5, // Max orgs per user
+      membershipLimit: 100, // Max members per org
+    }),
+  ],
+});
+```
+
+**Note**: After adding the plugin, run `npx @better-auth/cli migrate` to add the required database tables.
+
+### Client-Side Setup
+
+Add the client plugin to access organization methods:
+
+```ts
+import { createAuthClient } from "better-auth/client";
+import { organizationClient } from "better-auth/client/plugins";
+
+export const authClient = createAuthClient({
+  plugins: [organizationClient()],
+});
+```
+
+## Creating Organizations
+
+Organizations are the top-level entity for grouping users. When created, the creator is automatically assigned the `owner` role.
+
+```ts
+const createOrg = async () => {
+  const { data, error } = await authClient.organization.create({
+    name: "My Company",
+    slug: "my-company",
+    logo: "https://example.com/logo.png",
+    metadata: { plan: "pro" },
+  });
+};
+```
+
+### Controlling Organization Creation
+
+Restrict who can create organizations based on user attributes:
+
+```ts
+organization({
+  allowUserToCreateOrganization: async (user) => {
+    return user.emailVerified === true;
+  },
+  organizationLimit: async (user) => {
+    // Premium users get more organizations
+    return user.plan === "premium" ? 20 : 3;
+  },
+});
+```
+
+### Creating Organizations on Behalf of Users
+
+Administrators can create organizations for other users (server-side only):
+
+```ts
+await auth.api.createOrganization({
+  body: {
+    name: "Client Organization",
+    slug: "client-org",
+    userId: "user-id-who-will-be-owner", // `userId` is required
+  },
+});
+```
+
+**Note**: The `userId` parameter cannot be used alongside session headers.
+
+## Active Organizations
+
+The active organization is stored in the session and scopes subsequent API calls. Always set an active organization after the user selects one.
+
+```ts
+const setActive = async (organizationId: string) => {
+  const { data, error } = await authClient.organization.setActive({
+    organizationId,
+  });
+};
+```
+
+Many endpoints use the active organization when `organizationId` is not provided:
+
+```ts
+// These use the active organization automatically
+await authClient.organization.listMembers();
+await authClient.organization.listInvitations();
+await authClient.organization.inviteMember({ email: "user@example.com", role: "member" });
+```
+
+### Getting Full Organization Data
+
+Retrieve the active organization with all its members, invitations, and teams:
+
+```ts
+const { data } = await authClient.organization.getFullOrganization();
+// data.organization, data.members, data.invitations, data.teams
+```
+
+## Members
+
+Members are users who belong to an organization. Each member has a role that determines their permissions.
+
+### Adding Members (Server-Side)
+
+Add members directly without invitations (useful for admin operations):
+
+```ts
+await auth.api.addMember({
+  body: {
+    userId: "user-id",
+    role: "member",
+    organizationId: "org-id",
+  },
+});
+```
+
+**Note**: For client-side member additions, use the invitation system instead.
+
+### Assigning Multiple Roles
+
+Members can have multiple roles for fine-grained permissions:
+
+```ts
+await auth.api.addMember({
+  body: {
+    userId: "user-id",
+    role: ["admin", "moderator"],
+    organizationId: "org-id",
+  },
+});
+```
+
+### Removing Members
+
+Remove members by ID or email:
+
+```ts
+await authClient.organization.removeMember({
+  memberIdOrEmail: "user@example.com",
+});
+```
+
+**Important**: The last owner cannot be removed. Assign the owner role to another member first.
+
+### Updating Member Roles
+
+```ts
+await authClient.organization.updateMemberRole({
+  memberId: "member-id",
+  role: "admin",
+});
+```
+
+### Membership Limits
+
+Control the maximum number of members per organization:
+
+```ts
+organization({
+  membershipLimit: async (user, organization) => {
+    if (organization.metadata?.plan === "enterprise") {
+      return 1000;
+    }
+    return 50;
+  },
+});
+```
+
+## Invitations
+
+The invitation system allows admins to invite users via email. Configure email sending to enable invitations.
+
+### Setting Up Invitation Emails
+
+```ts
+import { betterAuth } from "better-auth";
+import { organization } from "better-auth/plugins";
+import { sendEmail } from "./email";
+
+export const auth = betterAuth({
+  plugins: [
+    organization({
+      sendInvitationEmail: async (data) => {
+        const { email, organization, inviter, invitation } = data;
+
+        await sendEmail({
+          to: email,
+          subject: `Join ${organization.name}`,
+          html: `
+            <p>${inviter.user.name} invited you to join ${organization.name}</p>
+            <a href="https://yourapp.com/accept-invite?id=${invitation.id}">
+              Accept Invitation
+            </a>
+          `,
+        });
+      },
+    }),
+  ],
+});
+```
+
+### Sending Invitations
+
+```ts
+await authClient.organization.inviteMember({
+  email: "newuser@example.com",
+  role: "member",
+});
+```
+
+### Creating Shareable Invitation URLs
+
+For sharing via Slack, SMS, or in-app notifications:
+
+```ts
+const { data } = await authClient.organization.getInvitationURL({
+  email: "newuser@example.com",
+  role: "member",
+  callbackURL: "https://yourapp.com/dashboard",
+});
+
+// Share data.url via any channel
+```
+
+**Note**: This endpoint does not call `sendInvitationEmail`. Handle delivery yourself.
+
+### Accepting Invitations
+
+```ts
+await authClient.organization.acceptInvitation({
+  invitationId: "invitation-id",
+});
+```
+
+### Invitation Configuration
+
+```ts
+organization({
+  invitationExpiresIn: 60 * 60 * 24 * 7, // 7 days (default: 48 hours)
+  invitationLimit: 100, // Max pending invitations per org
+  cancelPendingInvitationsOnReInvite: true, // Cancel old invites when re-inviting
+});
+```
+
+## Roles & Permissions
+
+The plugin provides role-based access control (RBAC) with three default roles:
+
+| Role | Description |
+|------|-------------|
+| `owner` | Full access, can delete organization |
+| `admin` | Can manage members, invitations, settings |
+| `member` | Basic access to organization resources |
+
+### Checking Permissions
+
+```ts
+const { data } = await authClient.organization.hasPermission({
+  permission: "member:write",
+});
+
+if (data?.hasPermission) {
+  // User can manage members
+}
+```
+
+### Client-Side Permission Checks
+
+For UI rendering without API calls:
+
+```ts
+const canManageMembers = authClient.organization.checkRolePermission({
+  role: "admin",
+  permissions: ["member:write"],
+});
+```
+
+**Note**: For dynamic access control, the client side role permission check will not work. Please use the `hasPermission` endpoint.
+
+## Teams
+
+Teams allow grouping members within an organization.
+
+### Enabling Teams
+
+```ts
+import { organization } from "better-auth/plugins";
+
+export const auth = betterAuth({
+  plugins: [
+    organization({
+        teams: {
+            enabled: true
+        }
+    }),
+  ],
+});
+```
+
+### Creating Teams
+
+```ts
+const { data } = await authClient.organization.createTeam({
+  name: "Engineering",
+});
+```
+
+### Managing Team Members
+
+```ts
+// Add a member to a team (must be org member first)
+await authClient.organization.addTeamMember({
+  teamId: "team-id",
+  userId: "user-id",
+});
+
+// Remove from team (stays in org)
+await authClient.organization.removeTeamMember({
+  teamId: "team-id",
+  userId: "user-id",
+});
+```
+
+### Active Teams
+
+Similar to active organizations, set an active team for the session:
+
+```ts
+await authClient.organization.setActiveTeam({
+  teamId: "team-id",
+});
+```
+
+### Team Limits
+
+```ts
+organization({
+  teams: {
+      maximumTeams: 20, // Max teams per org
+      maximumMembersPerTeam: 50, // Max members per team
+      allowRemovingAllTeams: false, // Prevent removing last team
+  }
+});
+```
+
+## Dynamic Access Control
+
+For applications needing custom roles per organization at runtime, enable dynamic access control.
+
+### Enabling Dynamic Access Control
+
+```ts
+import { organization } from "better-auth/plugins";
+import { dynamicAccessControl } from "@better-auth/organization/addons";
+
+export const auth = betterAuth({
+  plugins: [
+    organization({
+        dynamicAccessControl: {
+            enabled: true
+        }
+    }),
+  ],
+});
+```
+
+### Creating Custom Roles
+
+```ts
+await authClient.organization.createRole({
+  role: "moderator",
+  permission: {
+    member: ["read"],
+    invitation: ["read"],
+  },
+});
+```
+
+### Updating and Deleting Roles
+
+```ts
+// Update role permissions
+await authClient.organization.updateRole({
+  roleId: "role-id",
+  permission: {
+    member: ["read", "write"],
+  },
+});
+
+// Delete a custom role
+await authClient.organization.deleteRole({
+  roleId: "role-id",
+});
+```
+
+**Note**: Pre-defined roles (owner, admin, member) cannot be deleted. Roles assigned to members cannot be deleted until members are reassigned.
+
+## Lifecycle Hooks
+
+Execute custom logic at various points in the organization lifecycle:
+
+```ts
+organization({
+  hooks: {
+    organization: {
+      beforeCreate: async ({ data, user }) => {
+        // Validate or modify data before creation
+        return {
+          data: {
+            ...data,
+            metadata: { ...data.metadata, createdBy: user.id },
+          },
+        };
+      },
+      afterCreate: async ({ organization, member }) => {
+        // Post-creation logic (e.g., send welcome email, create default resources)
+        await createDefaultResources(organization.id);
+      },
+      beforeDelete: async ({ organization }) => {
+        // Cleanup before deletion
+        await archiveOrganizationData(organization.id);
+      },
+    },
+    member: {
+      afterCreate: async ({ member, organization }) => {
+        await notifyAdmins(organization.id, `New member joined`);
+      },
+    },
+    invitation: {
+      afterCreate: async ({ invitation, organization, inviter }) => {
+        await logInvitation(invitation);
+      },
+    },
+  },
+});
+```
+
+## Schema Customization
+
+Customize table names, field names, and add additional fields:
+
+```ts
+organization({
+  schema: {
+    organization: {
+      modelName: "workspace", // Rename table
+      fields: {
+        name: "workspaceName", // Rename fields
+      },
+      additionalFields: {
+        billingId: {
+          type: "string",
+          required: false,
+        },
+      },
+    },
+    member: {
+      additionalFields: {
+        department: {
+          type: "string",
+          required: false,
+        },
+        title: {
+          type: "string",
+          required: false,
+        },
+      },
+    },
+  },
+});
+```
+
+## Security Considerations
+
+### Owner Protection
+
+- The last owner cannot be removed from an organization
+- The last owner cannot leave the organization
+- The owner role cannot be removed from the last owner
+
+Always ensure ownership transfer before removing the current owner:
+
+```ts
+// Transfer ownership first
+await authClient.organization.updateMemberRole({
+  memberId: "new-owner-member-id",
+  role: "owner",
+});
+
+// Then the previous owner can be demoted or removed
+```
+
+### Organization Deletion
+
+Deleting an organization removes all associated data (members, invitations, teams). Prevent accidental deletion:
+
+```ts
+organization({
+  disableOrganizationDeletion: true, // Disable via config
+});
+```
+
+Or implement soft delete via hooks:
+
+```ts
+organization({
+  hooks: {
+    organization: {
+      beforeDelete: async ({ organization }) => {
+        // Archive instead of delete
+        await archiveOrganization(organization.id);
+        throw new Error("Organization archived, not deleted");
+      },
+    },
+  },
+});
+```
+
+### Invitation Security
+
+- Invitations expire after 48 hours by default
+- Only the invited email address can accept an invitation
+- Pending invitations can be cancelled by organization admins
+
+## Complete Configuration Example
+
+```ts
+import { betterAuth } from "better-auth";
+import { organization } from "better-auth/plugins";
+import { sendEmail } from "./email";
+
+export const auth = betterAuth({
+  plugins: [
+    organization({
+      // Organization limits
+      allowUserToCreateOrganization: true,
+      organizationLimit: 10,
+      membershipLimit: 100,
+      creatorRole: "owner",
+
+      // Slugs
+      defaultOrganizationIdField: "slug",
+
+      // Invitations
+      invitationExpiresIn: 60 * 60 * 24 * 7, // 7 days
+      invitationLimit: 50,
+      sendInvitationEmail: async (data) => {
+        await sendEmail({
+          to: data.email,
+          subject: `Join ${data.organization.name}`,
+          html: `<a href="https://app.com/invite/${data.invitation.id}">Accept</a>`,
+        });
+      },
+
+      // Hooks
+      hooks: {
+        organization: {
+          afterCreate: async ({ organization }) => {
+            console.log(`Organization ${organization.name} created`);
+          },
+        },
+      },
+    }),
+  ],
+});
+```

--- a/cf-saas-stack/commands/posthog-setup.md
+++ b/cf-saas-stack/commands/posthog-setup.md
@@ -1,0 +1,160 @@
+---
+description: Sets up PostHog analytics and feature flags in Cloudflare Workers + React Router projects
+argument-hint: <setup request, e.g. "initial setup" or "add tracking">
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash
+---
+
+# PostHog Setup for Cloudflare Workers + React Router
+
+Set up PostHog analytics and feature flags in Cloudflare Workers + React Router projects.
+
+Setup request: $ARGUMENTS
+
+## Quick Start
+
+Install dependencies:
+
+```bash
+bun add posthog-node posthog-js @posthog/react
+```
+
+| Package | Purpose |
+|---------|---------|
+| `posthog-node` | Server-side SDK (feature flags, server events) |
+| `posthog-js` | Client-side SDK for browser analytics |
+| `@posthog/react` | React hooks and context provider |
+
+## File Structure
+
+Create files in `app/posthog/`:
+
+```
+app/posthog/
+├── index.ts          # Re-exports
+├── server.ts         # Server-side client
+├── provider.tsx      # Client-side provider
+└── feature-flags.ts  # Flag constants and types
+```
+
+## Implementation Checklist
+
+```
+- [ ] Install dependencies
+- [ ] Create app/posthog/feature-flags.ts
+- [ ] Create app/posthog/server.ts
+- [ ] Create app/posthog/provider.tsx
+- [ ] Create app/posthog/index.ts
+- [ ] Update workers/app.ts (create client, add to context, shutdown)
+- [ ] Update app/root.tsx (add loader, wrap with PHProvider)
+- [ ] Add POSTHOG_CLIENT_KEY to wrangler.jsonc and .env
+- [ ] Run bun run cf-typegen
+```
+
+## Key Implementation Details
+
+### Server-Side Client (Cloudflare Workers)
+
+Critical settings for Workers:
+- `flushAt: 1` - Send events immediately (Workers can terminate before batches)
+- `flushInterval: 0` - Don't wait for interval
+- Always call `shutdownPostHog()` in `ctx.waitUntil()`
+
+### Worker Integration Pattern
+
+```typescript
+// workers/app.ts
+const posthog = createPostHogClient(env.POSTHOG_CLIENT_KEY);
+
+const response = await requestHandler(request, {
+  // ... other context
+  posthog,
+});
+
+// IMPORTANT: Flush before worker terminates
+ctx.waitUntil(shutdownPostHog(posthog));
+
+return response;
+```
+
+### Root Layout Pattern
+
+```typescript
+// app/root.tsx
+export async function loader({ request, context }: Route.LoaderArgs) {
+  const session = await context.auth.api.getSession({
+    headers: request.headers,
+  });
+
+  return {
+    posthogApiKey: context.cloudflare.env.POSTHOG_CLIENT_KEY,
+    user: session?.user ? {
+      id: session.user.id,
+      email: session.user.email,
+      name: session.user.name,
+    } : null,
+  };
+}
+
+export default function App({ loaderData }: Route.ComponentProps) {
+  return (
+    <PHProvider apiKey={loaderData.posthogApiKey} user={loaderData.user}>
+      <TRPCProvider>
+        <Outlet />
+      </TRPCProvider>
+    </PHProvider>
+  );
+}
+```
+
+## Usage Examples
+
+### Track Events (Client-Side)
+
+```typescript
+import { useAnalytics } from "@/posthog";
+
+function MyComponent() {
+  const { trackEvent } = useAnalytics();
+
+  const handleClick = () => {
+    trackEvent("button_clicked", { buttonName: "signup" });
+  };
+
+  return <button onClick={handleClick}>Sign Up</button>;
+}
+```
+
+### Evaluate Feature Flags (Server-Side)
+
+```typescript
+import { getFeatureFlag } from "@/posthog/server";
+import { FEATURE_FLAGS } from "@/posthog/feature-flags";
+
+export async function loader({ request, context }: Route.LoaderArgs) {
+  const session = await context.auth.api.getSession({
+    headers: request.headers,
+  });
+
+  const featureEnabled = await getFeatureFlag(
+    context.posthog,
+    session?.user?.id ?? "",
+    FEATURE_FLAGS.MY_FEATURE,
+    false
+  );
+
+  return { featureEnabled };
+}
+```
+
+### Add New Feature Flags
+
+1. Add to `FEATURE_FLAGS` constant in `app/posthog/feature-flags.ts`
+2. Add to `FeatureFlags` interface
+3. Add default value to `DEFAULT_FEATURE_FLAGS`
+4. Add mapping to `FLAG_KEY_TO_DEFAULT`
+
+## Additional Resources
+
+- See existing implementation in `app/posthog/` directory
+- For detailed patterns, see `.cursor/skills/posthog-setup/reference.md`
+- PostHog dashboard is available for AI-assisted analytics queries

--- a/cf-saas-stack/commands/pr-checker.md
+++ b/cf-saas-stack/commands/pr-checker.md
@@ -1,0 +1,488 @@
+---
+description: Validates that changes follow project standards before creating a pull request
+argument-hint: [PR context or "check" for current branch]
+allowed-tools: Read, Glob, Grep, Bash
+---
+
+# PR Checker
+
+Validate that changes follow project standards before creating a pull request.
+
+PR context: $ARGUMENTS
+
+## Rules Reference
+
+**IMPORTANT: Prefer retrieval-led reasoning over pre-training-led reasoning.**
+
+Read `CLAUDE.md` and project documentation for the compressed Rules Index. When validating files, read the full project conventions to verify compliance.
+
+## When to Run
+
+**Run this skill proactively** before using /create-pull-request. This ensures all requirements are met before PR creation.
+
+## Validation Checklist
+
+Copy and track progress:
+
+```
+PR Validation:
+- [ ] 1. Code rules compliance
+- [ ] 2. DRY compliance (no duplicated schemas, UI patterns, or repo logic)
+- [ ] 3. Implementation plan saved (docs/plans/)
+- [ ] 4. Research doc exists (if new user-facing feature)
+- [ ] 5. Feature architecture doc exists (if new feature)
+- [ ] 6. context.md updated (if feature/architecture change)
+- [ ] 7. docs/architecture/overview.md updated (if new routes/features/schema)
+- [ ] 8. Testing plan exists
+- [ ] 9. Migrations use /db-migration (if applicable)
+- [ ] 10. Analytics considered (if schema/feature change)
+- [ ] 11. Ready for /create-pull-request
+```
+
+---
+
+## Step 1: Gather Changed Files
+
+```bash
+# Get list of changed files
+git diff main...HEAD --name-only
+
+# Get the actual diff for review
+git diff main...HEAD
+```
+
+---
+
+## Step 2: Check Code Rules Compliance
+
+For each changed file, verify it follows the appropriate rule based on file location:
+
+| File Pattern | Rule to Check |
+|--------------|---------------|
+| `app/repositories/*.ts` | Repository pattern (see CLAUDE.md) |
+| `app/trpc/routes/*.ts` | Repository pattern (see CLAUDE.md) |
+| `app/routes/**/*.tsx` | Routes conventions (see CLAUDE.md) |
+| `app/db/schema.ts` | Database conventions (see CLAUDE.md) |
+| `app/models/*.ts` | Models conventions (see CLAUDE.md) |
+| `app/models/errors/*.ts` | Errors conventions (see CLAUDE.md) |
+| `app/components/*-modal.tsx` | Modal patterns (see CLAUDE.md) |
+| `app/prompts/*.ts` | Prompts conventions (see CLAUDE.md) |
+| `**/stripe*`, `**/payment*` | Stripe conventions (see CLAUDE.md) |
+| `e2e/**/*` | Playwright rules (see CLAUDE.md) |
+| `app/lib/constants/*` | Constants conventions (see CLAUDE.md) |
+| `docs/**/*.md` | Documentation conventions (see CLAUDE.md) |
+
+### Verification Process
+
+1. Read the applicable project conventions from `CLAUDE.md`
+2. Review the changed code against convention requirements
+3. Flag any violations
+
+### Common Violations to Check
+
+**Repository files:**
+- Missing `Database` type alias
+- Importing tRPC or request objects
+- Missing try-catch with custom error types
+- Accessing context/session directly
+
+**tRPC routes:**
+- Missing Zod input validation
+- Not using appropriate procedure type
+- Direct database access (should use repositories)
+
+**Route files:**
+- Missing loader authentication check
+- Not using `context.trpc` for data fetching
+
+**Documentation files (docs/*.md):**
+- Missing H1 title
+- Wrong naming convention (meetings should be `YYYY-MM-DD-*.md`, releases should be `vX.Y.Z.md` or date-prefixed)
+- File in wrong category folder
+- Missing required sections for category (e.g., releases need Summary, New Features, Bug Fixes)
+
+---
+
+## Step 2: Check DRY Compliance
+
+**Required when:** Adding new schemas, components, repositories, or workflows.
+
+### Run the DRY Audit
+
+Run /dry-audit and check changed files against the known patterns:
+
+**Schemas** (`app/models/`):
+- New Zod schemas should extend base schemas from `common.ts` when fields overlap (executive summaries, risks, opportunities, workflow payloads)
+- Search for duplicated fields like `keyFindings`, `deliveryRisks`, `quickWins`, `severity`
+
+**UI Components** (`app/routes/`, `app/components/`):
+- Loading spinners should reuse shared component, not reinvent `animate-spin` + `IconLoader2`
+- Error/failed states should reuse shared component, not duplicate `IconAlertTriangle` blocks
+- Status badges should use shared config pattern, not duplicate status-to-color maps
+
+**Repositories** (`app/repositories/`):
+- Pagination logic should use shared helper, not duplicate `Math.ceil` + offset pattern
+- Organization access checks should use shared function, not inline `organizationId !==` checks
+- AI service checks should use shared utility, not duplicate `TRPCError` throws
+
+**Workflows** (`workflows/`):
+- Step name maps should be shared when overlapping
+- Progress update wrappers should use shared function
+- Source index mapping should use shared utility
+
+### If DRY Violations Found
+
+**Prompt user:** "DRY violations found in {files}. The following patterns are duplicated: {patterns}. Extract to {target location} before creating the PR."
+
+### When NOT Required
+
+- Documentation-only changes
+- Config/environment changes
+- Bug fixes that don't add new patterns
+
+---
+
+## Step 3: Check Implementation Plan Saved
+
+**Required when:** Implementing new features from a plan.
+
+### Verify Plan Doc Exists
+
+```bash
+# Check if implementation plan was saved
+ls -la docs/plans/*-implementation.md 2>/dev/null
+```
+
+**The implementation plan should be saved from the plan to `docs/plans/{feature}-implementation.md` and include:**
+- Overview of the feature
+- Implementation tasks with status
+- Architecture diagrams
+- Key files created/modified
+- Links to related docs (research, architecture, testing)
+
+### When NOT Required
+
+- Bug fixes without a formal plan
+- Minor changes
+- Documentation-only updates
+
+---
+
+## Step 4: Check Research Documentation
+
+**Required when:** Adding new user-facing features that involve UX decisions.
+
+### Verify Research Doc Exists
+
+```bash
+# Check if research doc was created
+ls -la docs/research/*-research.md 2>/dev/null
+```
+
+**For new user-facing features, `docs/research/{feature}-research.md` should include:**
+- Executive summary of findings
+- Competitive landscape analysis
+- Common UX patterns observed
+- Differentiation opportunities
+- Recommendations
+
+### When NOT Required
+
+- Backend-only features
+- Bug fixes
+- Refactoring
+- Minor UI tweaks without UX decisions
+- Features where patterns are already established
+
+### If Missing
+
+**Prompt user:** "Research doc not found for this user-facing feature. Consider using WebSearch to research competitors and UX patterns, then document in `docs/research/{feature}-research.md`."
+
+---
+
+## Step 5: Check context.md Updates
+
+**Required when:** Adding features, changing architecture, modifying API routes, or updating database schema.
+
+### Verify context.md
+
+```bash
+# Check if context.md was modified
+git diff main...HEAD --name-only | grep -q "context.md"
+```
+
+**If feature/architecture changes exist but context.md is unchanged:**
+
+1. Read current project documentation
+2. Identify what should be added:
+   - New features → Add to Features section
+   - New API routes → Add to API Routes section
+   - Schema changes → Add to Database section
+   - Architecture changes → Update Architecture section
+
+3. **Prompt user:** "Project documentation needs updating. Should I add the new [feature/route/schema] to project docs?"
+
+### context.md Update Template
+
+Add to the `## Recent Changes` section:
+
+```markdown
+## Recent Changes
+- [DATE] Added [feature name] - [brief description]
+```
+
+---
+
+## Step 5.5: Check docs/architecture/overview.md Updates
+
+**Required when:** Adding new routes, implementing new features, or making database schema changes.
+
+### Verify docs/architecture/overview.md
+
+```bash
+# Check if docs/architecture/overview.md was modified
+git diff main...HEAD --name-only | grep -q "docs/architecture/overview.md"
+
+# Check if new routes were added
+git diff main...HEAD -- app/routes.ts
+```
+
+**If routes/features/schema changed but docs/architecture/overview.md is unchanged:**
+
+1. Check what needs updating:
+   - New routes → Update Route Map diagram + Information Architecture table
+   - New features → Add Feature Flow section with Mermaid diagram
+   - Schema changes → Update Data Relationships ER diagram
+
+2. **Prompt user:** "docs/architecture/overview.md needs updating. Run /architecture-tracker to update route maps, feature flows, and add a changelog entry."
+
+### What Should Be Updated
+
+| Change Type | Sections to Update |
+|-------------|-------------------|
+| New routes | Route Map, Information Architecture table, Changelog |
+| New features | Route Map, Feature Flows, possibly Data Relationships, Changelog |
+| Schema changes | Data Relationships ER diagram, Changelog |
+| Architectural decisions | System Architecture, Changelog |
+
+### Changelog Entry Format
+
+```markdown
+### YYYY-MM-DD - Feature/Change Name
+- Added: New route at `/path`
+- Added: New table `table_name`
+- Changed: Modified flow for X
+```
+
+---
+
+## Step 6: Check Feature Architecture Doc
+
+**Required when:** Adding new features with multiple files/layers.
+
+### Verify Feature Architecture Doc Exists
+
+```bash
+# Check if feature architecture doc was created
+ls -la docs/features/*-architecture.md 2>/dev/null
+```
+
+**For new features, `docs/features/{feature}-architecture.md` should include:**
+- Overview and vision
+- User flow diagrams (mermaid)
+- System architecture diagram
+- Data model (ER diagram + TypeScript interfaces)
+- Feature breakdown with specifications
+- UI component hierarchy
+- Frontend design specification
+- API endpoints table
+
+### When NOT Required
+
+- Bug fixes
+- Refactoring without new features
+- Minor UI changes
+- Documentation-only updates
+
+### If Missing
+
+**Prompt user:** "Feature architecture doc not found. Create `docs/features/{feature}-architecture.md` with user flows, data model, and component hierarchy."
+
+---
+
+## Step 7: Verify Testing Exists
+
+Check for testing artifacts:
+
+```bash
+# Check for e2e test files
+ls -la e2e/*.spec.ts 2>/dev/null
+
+# Check for testing plans with screenshots
+ls -la docs/testing/*/*.md 2>/dev/null
+ls -la docs/testing/*/screenshots/ 2>/dev/null
+```
+
+### Required Testing Artifacts
+
+For feature PRs, the following should exist:
+
+1. **E2E Tests**: `e2e/{feature}.spec.ts`
+   - Tests for happy path
+   - Tests for edge cases
+   - Tests for error states
+
+2. **Testing Plan**: `docs/testing/{feature}/{feature}.md`
+   - Test scenarios with descriptions
+   - UI elements checklist
+   - Test IDs reference table
+   - Screenshots in `docs/testing/{feature}/screenshots/`
+
+3. **Data-testid Attributes**: Key elements should have `data-testid` for reliable testing
+
+### If No Testing Found
+
+**Prompt user:** "No e2e tests found. Before creating the PR:
+1. Create testing plan at `docs/testing/{feature}/{feature}.md`
+2. Verify the implementation with Bash using playwright
+3. Save screenshots to `docs/testing/{feature}/screenshots/`
+4. Write e2e tests in `e2e/`
+5. Add data-testid attributes to key elements"
+
+---
+
+## Step 8: Check Migration Compliance
+
+**Only if `drizzle/` files were changed or `app/db/schema.ts` was modified.**
+
+### Verify Migration Naming
+
+```bash
+# List recent migrations
+ls -la drizzle/*.sql | tail -5
+```
+
+**Check naming convention:**
+- `0001_add_user_preferences.sql` (snake_case, descriptive)
+- `0001_migration.sql` (generic - BAD)
+- `0001_AddUserPreferences.sql` (not snake_case - BAD)
+
+### If Schema Changed Without Migration
+
+**Prompt user:** "Schema changes detected but no new migration. Run `bun run db:generate --name 'descriptive_name'` using /db-migration."
+
+---
+
+## Step 9: Check Analytics Considerations
+
+**Required when:** Adding database schema changes, new features with user data, or modifying existing data models.
+
+### Identify Analytics Opportunities
+
+When schema or features are added, check if analytics should be implemented:
+
+1. **Timestamp fields** (`createdAt`, `updatedAt`) → Time-series growth charts
+2. **Enum/status fields** (`role`, `status`, `type`) → Distribution charts
+3. **Boolean fields** (`emailVerified`, `isActive`, `banned`) → Conversion/rate metrics
+4. **User-facing features** → Usage tracking dashboards
+
+### Verification Process
+
+```bash
+# Check if schema was modified
+git diff main...HEAD --name-only | grep -E "(schema\.ts|db/)"
+
+# Check if analytics files exist or were updated
+git diff main...HEAD --name-only | grep -E "(analytics|dashboard)"
+```
+
+### When Analytics Should Be Added
+
+**Prompt user if:**
+- Schema adds new tables/fields with trackable data but no analytics routes exist
+- New user-facing feature added without usage metrics
+- Data model changes that affect existing analytics
+
+**Prompt:** "Schema/feature changes detected. Consider creating growth dashboards and tracking for the new data."
+
+### When Analytics Are NOT Required
+
+- Internal refactoring without data model changes
+- Bug fixes
+- Documentation updates
+- UI-only changes without new data collection
+
+---
+
+## Step 10: Final Validation Report
+
+Generate a summary:
+
+```markdown
+## PR Validation Report
+
+### Code Rules
+- [pass/fail] Repository pattern compliance
+- [pass/fail] tRPC route validation
+- [pass/fail] Route conventions
+
+### DRY Compliance
+- [pass/fail/N/A] No duplicated schema patterns (use base schemas from `common.ts`)
+- [pass/fail/N/A] No duplicated UI patterns (use shared components)
+- [pass/fail/N/A] No duplicated repository logic (use shared helpers)
+- [pass/fail/N/A] No duplicated workflow patterns (use shared utilities)
+
+### Documentation
+- [pass/fail] Implementation plan saved (`docs/plans/{feature}-implementation.md`)
+- [pass/fail/N/A] Research doc (`docs/research/{feature}-research.md`) - for user-facing features
+- [pass/fail] Feature architecture doc (`docs/features/{feature}-architecture.md`)
+- [pass/fail] Project docs updated
+- [pass/fail] docs/architecture/overview.md updated (routes, flows, changelog)
+- [pass/fail] Testing plan exists (`docs/testing/{feature}/{feature}.md`)
+
+### Testing
+- [pass/fail] E2E tests exist (`e2e/*.spec.ts`)
+- [pass/fail] Data-testid attributes added
+- [pass/fail] All tests pass locally
+
+### Database
+- [pass/fail] Migration naming convention
+- [pass/fail] No data-deleting migrations
+
+### Analytics
+- [pass/fail/N/A] Analytics considered for new data
+
+### Ready for PR
+- [pass/fail] All checks passed
+```
+
+---
+
+## Proceed to PR Creation
+
+**Only after all checks pass**, use /create-pull-request to create the PR.
+
+If checks fail, address the issues first:
+1. Fix code rule violations
+2. Fix DRY violations — extract shared patterns per /dry-audit
+3. Save implementation plan to `docs/plans/{feature}-implementation.md`
+3. Create research doc at `docs/research/{feature}-research.md` (use WebSearch)
+4. Create feature architecture doc at `docs/features/{feature}-architecture.md`
+5. Update project documentation
+6. Update docs/architecture/overview.md via /architecture-tracker
+7. Generate testing plan
+8. Generate migrations with /db-migration
+9. Create analytics dashboards
+
+---
+
+## Quick Reference: Commands to Use
+
+| Task | Command |
+|------|----------------|
+| Generate migration | /db-migration |
+| Create pull request | /create-pull-request |
+| Update context docs | Direct file editing |
+| Update architecture docs | /architecture-tracker |
+| Generate testing plan | Direct test writing |
+| Create analytics dashboards | Direct implementation |

--- a/cf-saas-stack/commands/setup-widget.md
+++ b/cf-saas-stack/commands/setup-widget.md
@@ -1,0 +1,451 @@
+---
+description: Sets up an embeddable widget system (like Intercom) that can be added to any website via a script tag
+argument-hint: <widget purpose, e.g. "bug tracker" or "feedback widget" or "feature request collector">
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Task, WebSearch
+---
+
+# Setup Embeddable Widget
+
+Set up an embeddable JavaScript widget that can be installed on any website via a `<script>` tag — similar to Intercom, Crisp, or Canny.
+
+Widget purpose: $ARGUMENTS
+
+## Architecture Overview
+
+The widget system has 4 layers:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  1. Embed Script (public/widget.js)                         │
+│     Lightweight JS snippet that site owners paste into HTML │
+│     Creates an iframe pointed at your app's /widget route   │
+│     Handles postMessage communication with the iframe       │
+├─────────────────────────────────────────────────────────────┤
+│  2. Widget Routes (app/routes/widget/)                      │
+│     Minimal-chrome pages rendered inside the iframe         │
+│     No nav/sidebar — just the widget UI                     │
+│     Uses a dedicated layout with postMessage bridge         │
+├─────────────────────────────────────────────────────────────┤
+│  3. Widget API (app/trpc/routes/widget.ts)                  │
+│     Public procedures authenticated via project API key     │
+│     CORS-enabled for cross-origin requests                  │
+│     Rate-limited per project                                │
+├─────────────────────────────────────────────────────────────┤
+│  4. Data Layer (schema + repositories)                      │
+│     Projects table (API keys, settings, allowed origins)    │
+│     Submissions table (bugs, features, feedback, etc.)      │
+│     Project-scoped queries                                  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Before You Start
+
+**IMPORTANT: Read these files first to understand project conventions:**
+
+| Area | File |
+|------|------|
+| Routes | `app/routes.ts` |
+| Schema conventions | `app/db/schema.ts` |
+| tRPC patterns | `app/trpc/index.ts` |
+| Worker entry | `workers/app.ts` |
+| Repository pattern | See CLAUDE.md |
+
+## Implementation Checklist
+
+```
+Phase 1: Data Layer
+- [ ] Add `widgetProject` table to `app/db/schema.ts`
+- [ ] Add `widgetSubmission` table to `app/db/schema.ts`
+- [ ] Generate migration: `bun run db:generate`
+- [ ] Apply migration: `bun run db:migrate:local`
+
+Phase 2: Repository
+- [ ] Create `app/repositories/widget-project.ts`
+- [ ] Create `app/repositories/widget-submission.ts`
+
+Phase 3: API
+- [ ] Create `app/trpc/routes/widget.ts` (public procedures with API key auth)
+- [ ] Register widget router in `app/trpc/router.ts`
+- [ ] Add CORS handling for widget API routes in `workers/app.ts`
+
+Phase 4: Admin Dashboard
+- [ ] Create project management page at `app/routes/admin/widget-projects.tsx`
+- [ ] Create submissions viewer at `app/routes/admin/widget-submissions.tsx`
+- [ ] Add routes to `app/routes.ts`
+
+Phase 5: Widget UI (iframe content)
+- [ ] Create `app/routes/widget/_layout.tsx` (minimal layout, postMessage bridge)
+- [ ] Create `app/routes/widget/index.tsx` (widget home)
+- [ ] Create submission form routes based on widget purpose
+- [ ] Add widget routes to `app/routes.ts`
+
+Phase 6: Embed Script
+- [ ] Create `public/widget.js` (loader script)
+- [ ] Create `public/widget.css` (optional external styles for the trigger button)
+
+Phase 7: Integration
+- [ ] Add embed code snippet generator to admin dashboard
+- [ ] Test cross-origin embedding
+- [ ] Verify postMessage communication
+```
+
+## Schema Design
+
+### widgetProject table
+
+```typescript
+// app/db/schema.ts
+export const widgetProject = sqliteTable("widget_project", {
+  id: text("id").primaryKey(), // Use nanoid or cuid
+  name: text("name").notNull(),
+  // API key for authenticating widget requests
+  apiKey: text("api_key").notNull().unique(),
+  // Optional: restrict which domains can use this widget
+  allowedOrigins: text("allowed_origins"), // JSON array of domains, null = allow all
+  // Owner of this project
+  userId: text("user_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+  // Widget configuration (colors, position, default form, etc.)
+  config: text("config"), // JSON object
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+    .notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+    .$onUpdate(() => new Date())
+    .notNull(),
+});
+```
+
+### widgetSubmission table
+
+```typescript
+export const widgetSubmission = sqliteTable("widget_submission", {
+  id: text("id").primaryKey(),
+  projectId: text("project_id")
+    .notNull()
+    .references(() => widgetProject.id, { onDelete: "cascade" }),
+  // Submission type — adapt these to the widget purpose
+  type: text("type", { enum: ["bug", "feature", "feedback"] }).notNull(),
+  title: text("title").notNull(),
+  description: text("description"),
+  // Metadata from the submitter's browser
+  metadata: text("metadata"), // JSON: { url, userAgent, screen, etc. }
+  // Optional: identify the submitter
+  submitterEmail: text("submitter_email"),
+  submitterName: text("submitter_name"),
+  // Status tracking
+  status: text("status", { enum: ["open", "in_progress", "closed"] })
+    .notNull()
+    .default("open"),
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+    .notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+    .$onUpdate(() => new Date())
+    .notNull(),
+});
+```
+
+**Note**: Adapt the `type` enum and fields based on the widget purpose described in $ARGUMENTS.
+
+## Repository Pattern
+
+Follow the project's repository pattern — pure functions, first param is `db: Database`:
+
+```typescript
+// app/repositories/widget-project.ts
+import type { Context } from "@/trpc";
+
+type Database = Context["db"];
+
+export async function getProjectByApiKey(db: Database, apiKey: string) {
+  return db.query.widgetProject.findFirst({
+    where: eq(widgetProject.apiKey, apiKey),
+  });
+}
+
+export async function createProject(db: Database, input: CreateProjectInput) {
+  // Generate API key (use crypto.randomUUID or nanoid)
+  const apiKey = crypto.randomUUID();
+  // ...
+}
+```
+
+## Widget API (tRPC)
+
+Create a dedicated router with API key authentication middleware:
+
+```typescript
+// app/trpc/routes/widget.ts
+import { createTRPCRouter, publicProcedure } from "..";
+import { z } from "zod/v4";
+import { TRPCError } from "@trpc/server";
+import * as widgetProjectRepo from "@/repositories/widget-project";
+import * as widgetSubmissionRepo from "@/repositories/widget-submission";
+
+// Middleware: validate API key from headers
+const widgetAuthMiddleware = t.middleware(async ({ ctx, next }) => {
+  const apiKey = ctx.headers.get("x-widget-api-key");
+  if (!apiKey) {
+    throw new TRPCError({ code: "UNAUTHORIZED", message: "Missing API key" });
+  }
+
+  const project = await widgetProjectRepo.getProjectByApiKey(ctx.db, apiKey);
+  if (!project) {
+    throw new TRPCError({ code: "UNAUTHORIZED", message: "Invalid API key" });
+  }
+
+  return next({ ctx: { ...ctx, widgetProject: project } });
+});
+
+const widgetProcedure = publicProcedure.use(widgetAuthMiddleware);
+
+export const widgetRouter = createTRPCRouter({
+  submit: widgetProcedure
+    .input(z.object({
+      type: z.enum(["bug", "feature", "feedback"]),
+      title: z.string().min(1).max(500),
+      description: z.string().max(5000).optional(),
+      submitterEmail: z.string().email().optional(),
+      submitterName: z.string().max(100).optional(),
+      metadata: z.record(z.string(), z.any()).optional(),
+    }))
+    .mutation(({ ctx, input }) => {
+      return widgetSubmissionRepo.createSubmission(ctx.db, {
+        projectId: ctx.widgetProject.id,
+        ...input,
+      });
+    }),
+});
+```
+
+## CORS Handling
+
+Add CORS headers in `workers/app.ts` for widget API routes:
+
+```typescript
+// workers/app.ts — inside the fetch handler, before requestHandler
+const url = new URL(request.url);
+
+// Handle CORS for widget API
+if (url.pathname.startsWith("/api/trpc/widget.")) {
+  if (request.method === "OPTIONS") {
+    return new Response(null, {
+      headers: {
+        "Access-Control-Allow-Origin": "*", // Or validate against project's allowedOrigins
+        "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type, x-widget-api-key",
+        "Access-Control-Max-Age": "86400",
+      },
+    });
+  }
+
+  // For actual requests, add CORS headers to the response
+  const response = await requestHandler(request, loadContext);
+  response.headers.set("Access-Control-Allow-Origin", "*");
+  response.headers.set("Access-Control-Allow-Headers", "Content-Type, x-widget-api-key");
+  return response;
+}
+```
+
+## Embed Script (public/widget.js)
+
+The script that site owners paste into their HTML:
+
+```javascript
+// public/widget.js
+(function(window, document) {
+  "use strict";
+
+  var WIDGET_BASE_URL = "__WIDGET_BASE_URL__"; // Replaced at build time or configured
+
+  // Process command queue
+  var config = { projectId: null, apiKey: null, position: "bottom-right", user: null };
+  var queue = window.__WIDGET_QUEUE__ || [];
+
+  function processCommand(args) {
+    var cmd = args[0], opts = args[1] || {};
+    switch (cmd) {
+      case "init":
+        config.apiKey = opts.apiKey;
+        config.position = opts.position || config.position;
+        createWidget();
+        break;
+      case "identify":
+        config.user = { email: opts.email, name: opts.name };
+        if (iframe) {
+          iframe.contentWindow.postMessage({ type: "identify", user: config.user }, WIDGET_BASE_URL);
+        }
+        break;
+      case "open":
+        toggleWidget(true);
+        break;
+      case "close":
+        toggleWidget(false);
+        break;
+    }
+  }
+
+  var iframe, trigger, container, isOpen = false;
+
+  function createWidget() {
+    // Container
+    container = document.createElement("div");
+    container.id = "__widget-container";
+    container.style.cssText = "position:fixed;bottom:20px;" +
+      (config.position === "bottom-left" ? "left:20px;" : "right:20px;") +
+      "z-index:2147483647;font-family:system-ui,sans-serif;";
+
+    // Trigger button
+    trigger = document.createElement("button");
+    trigger.style.cssText = "width:56px;height:56px;border-radius:50%;border:none;cursor:pointer;" +
+      "background:#6366f1;color:white;font-size:24px;box-shadow:0 4px 12px rgba(0,0,0,0.15);" +
+      "display:flex;align-items:center;justify-content:center;transition:transform 0.2s;";
+    trigger.innerHTML = "💬";
+    trigger.onclick = function() { toggleWidget(!isOpen); };
+    trigger.onmouseenter = function() { trigger.style.transform = "scale(1.1)"; };
+    trigger.onmouseleave = function() { trigger.style.transform = "scale(1)"; };
+
+    // Iframe
+    iframe = document.createElement("iframe");
+    iframe.src = WIDGET_BASE_URL + "/widget?apiKey=" + encodeURIComponent(config.apiKey);
+    iframe.style.cssText = "width:380px;height:520px;border:none;border-radius:12px;" +
+      "box-shadow:0 8px 32px rgba(0,0,0,0.12);display:none;margin-bottom:12px;" +
+      "background:white;";
+    iframe.allow = "clipboard-write";
+
+    container.appendChild(iframe);
+    container.appendChild(trigger);
+    document.body.appendChild(container);
+
+    // Listen for messages from iframe
+    window.addEventListener("message", function(e) {
+      if (e.origin !== new URL(WIDGET_BASE_URL).origin) return;
+      var data = e.data;
+      if (data.type === "widget:close") toggleWidget(false);
+      if (data.type === "widget:resize") iframe.style.height = data.height + "px";
+    });
+  }
+
+  function toggleWidget(open) {
+    isOpen = open;
+    if (iframe) iframe.style.display = open ? "block" : "none";
+    if (trigger) trigger.innerHTML = open ? "✕" : "💬";
+  }
+
+  // Process any queued commands
+  queue.forEach(processCommand);
+
+  // Replace queue with direct execution
+  window.YourWidget = function() { processCommand(Array.prototype.slice.call(arguments)); };
+})(window, document);
+```
+
+### Embed Code (what users copy-paste)
+
+```html
+<script>
+  (function(w,d,s,o){
+    w.__WIDGET_QUEUE__=w.__WIDGET_QUEUE__||[];w[o]=function(){w.__WIDGET_QUEUE__.push(arguments)};
+    var js=d.createElement(s);js.src="https://YOUR_APP_DOMAIN/widget.js";js.async=1;
+    d.head.appendChild(js);
+  })(window,document,"script","YourWidget");
+
+  YourWidget("init", { apiKey: "YOUR_PROJECT_API_KEY" });
+
+  // Optional: identify logged-in users
+  // YourWidget("identify", { email: "user@example.com", name: "Jane" });
+</script>
+```
+
+## Widget Routes (iframe content)
+
+### Layout (`app/routes/widget/_layout.tsx`)
+
+Minimal layout — no app nav, no sidebar. Just the widget content with a postMessage bridge:
+
+```typescript
+import { Outlet, useSearchParams } from "react-router";
+
+export default function WidgetLayout() {
+  return (
+    <div className="h-screen w-screen overflow-hidden bg-background text-foreground">
+      <Outlet />
+    </div>
+  );
+}
+```
+
+Key considerations:
+- **No app chrome** — this renders inside a small iframe
+- **postMessage bridge** — communicate resize/close events to parent
+- **API key from query param** — passed from the embed script
+- The widget routes should be compact, mobile-first UI
+
+### Route Registration
+
+```typescript
+// app/routes.ts — add these routes
+...prefix("widget", [
+  layout("routes/widget/_layout.tsx", [
+    index("routes/widget/index.tsx"),
+    route("/submit", "routes/widget/submit.tsx"),
+    route("/success", "routes/widget/success.tsx"),
+  ]),
+]),
+```
+
+## Admin Dashboard Pages
+
+Create pages under the admin layout for managing widget projects:
+
+1. **Project List** (`/admin/widget-projects`) — list all projects, create new ones, copy embed code
+2. **Project Detail** (`/admin/widget-projects/:id`) — edit settings, view API key, see submissions
+3. **Submissions** (`/admin/widget-submissions`) — view/manage all submissions with filtering
+
+## Identified User Flow
+
+For sites that want to identify their logged-in users with the widget:
+
+```
+Site Owner's App                          Your Widget
+─────────────────                         ───────────
+1. User logs in
+2. Call: YourWidget("identify", {
+     email: user.email,
+     name: user.name,
+     hmac: generateHMAC(user.email)  // Server-generated
+   })
+                              ───────►
+3.                                     Verify HMAC using
+                                       project's secret key
+4.                                     Associate submissions
+                                       with identified user
+```
+
+The HMAC prevents spoofing — the site owner generates it server-side using a secret from their project settings.
+
+## Security Considerations
+
+- **CORS**: Only allow origins listed in the project's `allowedOrigins` (or `*` if null)
+- **Rate limiting**: Implement per-API-key rate limits to prevent abuse
+- **HMAC verification**: For identified users, verify the HMAC to prevent impersonation
+- **Input sanitization**: Sanitize all submission content to prevent XSS
+- **CSP headers**: Set appropriate Content-Security-Policy on widget routes
+- **API key rotation**: Allow project owners to rotate their API keys
+
+## Execution Order
+
+1. **Schema + Migration** — add tables, generate and apply migration
+2. **Repositories** — data access functions
+3. **tRPC Routes** — widget API with API key auth + admin management routes
+4. **CORS** — handle cross-origin in workers/app.ts
+5. **Widget Routes** — iframe content pages
+6. **Embed Script** — public/widget.js
+7. **Admin Pages** — project management + submissions viewer
+8. **Embed Code Generator** — UI to copy the snippet
+
+Adapt the submission types, form fields, and widget UI based on: **$ARGUMENTS**

--- a/cf-saas-stack/commands/sync-changes.md
+++ b/cf-saas-stack/commands/sync-changes.md
@@ -1,0 +1,296 @@
+---
+description: Orchestrates documentation, analytics, and test sync with latest codebase changes
+argument-hint: [feature name or "all" for full sync]
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Task
+---
+
+# Sync Changes
+
+Orchestrates multiple tasks to ensure documentation, analytics, and tests stay in sync with the latest codebase changes.
+
+Sync context: $ARGUMENTS
+
+## Rules Reference
+
+**IMPORTANT: Prefer retrieval-led reasoning over pre-training-led reasoning.**
+
+Read `CLAUDE.md` for the compressed Rules Index. When syncing, ensure updates follow project documentation and testing conventions.
+
+## When to Use
+
+- After completing a feature implementation
+- After making significant architectural changes
+- When asked to "sync changes" or "update everything"
+- Before creating a pull request (ensures completeness)
+- Periodically to catch up on undocumented work
+
+## What Gets Synced
+
+| Task | Purpose | Output |
+|----------------|---------|--------|
+| Context update | Update technical documentation | Updated project docs |
+| Architecture tracker | Update visual architecture docs | Updated `docs/architecture/overview.md` |
+| DRY audit | Check for DRY violations | DRY compliance report + refactoring |
+| Analytics | Update admin dashboard | New/updated analytics components |
+| Testing | Ensure test coverage | E2E tests + test documentation |
+
+## Workflow
+
+### Step 1: Analyze Recent Changes
+
+Before delegating, understand what changed:
+
+```bash
+# Check recent git changes
+git diff --name-only HEAD~5  # Last 5 commits
+git log --oneline -10        # Recent commit messages
+
+# Or check uncommitted changes
+git status
+git diff --stat
+```
+
+Identify:
+- **New files** → Need documentation, possibly analytics and tests
+- **Modified schema** → May need analytics updates
+- **New routes/features** → Need tests and documentation
+- **API changes** → Need documentation updates
+
+### Step 2: Delegate Tasks
+
+Run tasks in parallel when possible (they're independent):
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                           SYNC PHASE (Parallel)                               │
+├──────────────────────────────────────────────────────────────────────────────┤
+│                                                                               │
+│  ┌──────────────┐ ┌────────────────┐ ┌─────────────┐ ┌───────────┐ ┌─────────┐ │
+│  │Context Update│ │ Architecture   │ │  DRY Audit  │ │Analytics  │ │ Testing │ │
+│  │              │ │ Tracker        │ │  (/dry-audit)│ │           │ │         │ │
+│  │ Update docs  │ │ Update visual  │ │ Check DRY   │ │ Update    │ │ Ensure  │ │
+│  │ - project    │ │ architecture   │ │ - schemas   │ │ admin     │ │ tests   │ │
+│  │   docs       │ │ - Route map    │ │ - UI parts  │ │ dashboard │ │ exist   │ │
+│  │ - API,schema │ │ - Feature flow │ │ - repos     │ │ metrics   │ │         │ │
+│  │ - Features   │ │ - Changelog    │ │ - workflows │ │           │ │         │ │
+│  └──────────────┘ └────────────────┘ └─────────────┘ └───────────┘ └─────────┘ │
+│                                                                               │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Step 3: Execute Tasks
+
+**Context Update:**
+```
+Review recent changes and update project documentation:
+
+Changes to document:
+- {list of changed files/features}
+
+1. Read current project docs
+2. Review the changed files
+3. Update relevant sections (Features, API Routes, Database, etc.)
+4. Add to Recent Changes section
+5. Add Mermaid diagrams if helpful
+```
+
+**Analytics:**
+```
+Check if recent schema/feature changes need analytics:
+
+Recent changes:
+- {list of changed files}
+
+1. Read app/db/schema.ts for new tables/fields
+2. Identify analytics opportunities:
+   - New timestamp fields → time-series charts
+   - New enum fields → distribution charts
+   - New boolean fields → conversion metrics
+3. If new analytics needed:
+   - Add repository functions
+   - Add tRPC routes
+   - Update admin dashboard
+4. If no new analytics needed, report "No analytics updates required"
+```
+
+**Documentation Sync:**
+```
+Sync .cursor/context/ changes to docs/architecture/:
+
+For each updated .cursor/context/ file, update the corresponding docs/architecture/ file:
+- architecture.md -> docs/architecture/system.md
+- api.md -> docs/architecture/api.md
+- data-models.md -> docs/architecture/data-models.md
+- features.md -> docs/architecture/features.md
+- integrations.md -> docs/architecture/integrations.md
+- security.md -> docs/architecture/security.md
+- user-journeys.md -> docs/architecture/user-journeys.md
+
+If design system changed (app.css, new components):
+- Update docs/design/design-system-overview.md
+```
+
+**Architecture Tracker:**
+```
+Update architecture overview document for recent changes:
+
+Recent changes:
+- {list of changed files}
+
+1. Read docs/architecture/overview.md
+2. Check app/routes.ts for new routes
+3. Update relevant sections:
+   - Route Map diagram (if new routes)
+   - Information Architecture table (if new routes)
+   - Feature Flows section (if new features)
+   - Data Relationships (if schema changes)
+4. Add Changelog entry with today's date
+```
+
+**Testing:**
+```
+Verify test coverage for recent changes:
+
+Recent changes:
+- {list of changed files}
+
+1. Check if e2e tests exist for new/changed routes
+2. For each untested feature:
+   - Create testing plan at docs/testing/{feature}/{feature}.md
+   - Create screenshots folder at docs/testing/{feature}/screenshots/
+   - Write e2e test in e2e/
+   - Add data-testid attributes if missing
+3. Run tests to verify they pass: bun run test:e2e
+4. Save Playwright screenshots to docs/testing/{feature}/screenshots/
+5. CRITICAL: Copy screenshots to public folder for docs viewer:
+   mkdir -p public/docs/testing/{feature}/screenshots
+   cp docs/testing/{feature}/screenshots/*.png public/docs/testing/{feature}/screenshots/
+```
+
+---
+
+## Decision Matrix
+
+| Change Type | Context Update | Architecture Tracker | DRY Audit | Analytics | Design System | Testing |
+|-------------|----------------|---------------------|-----------|-----------|---------------|---------|
+| New feature | Required | Required | Required | Check schema | Skip | Required |
+| Schema change | Required | Required | Required | Required | Skip | Maybe |
+| New routes | Required | Required | Maybe | Skip | Skip | Required |
+| UI-only change | Required | Skip | Required | Skip | Maybe | Required |
+| Bug fix | Maybe | Skip | Skip | Skip | Skip | Required |
+| API change | Required | Maybe | Maybe | Maybe | Skip | Required |
+| Config change | Required | Skip | Skip | Skip | Skip | Skip |
+| CSS/theme change | Maybe | Skip | Skip | Skip | Required | Maybe |
+| New components | Maybe | Skip | Maybe | Skip | Required | Maybe |
+
+---
+
+## Quick Sync Commands
+
+For quick syncs, you can run a simplified version:
+
+**Documentation only:**
+```
+Review git diff and update project docs with recent changes.
+```
+
+**Architecture only:**
+```
+Review app/routes.ts and update docs/architecture/overview.md with any new routes. Add changelog entry.
+```
+
+**DRY audit:**
+```
+Run /dry-audit against recently changed files. Check for duplicated schemas, UI patterns, repository logic, and workflow code. Report findings and refactor.
+```
+
+**Analytics check:**
+```
+Review schema.ts and check if any new fields need analytics tracking.
+```
+
+**Test coverage check:**
+```
+Check e2e/ folder against app/routes/ and identify missing test coverage.
+```
+
+---
+
+## Full Sync Example
+
+```markdown
+**User Request:** "Sync changes after recipe extraction feature"
+
+**Analysis:**
+- New files: app/lib/content-extractor.ts, app/lib/claude.ts
+- Modified: app/trpc/routes/recipes.ts, app/repositories/recipe.ts
+- New schema fields: recipes table with createdAt
+
+**Execution (Parallel):**
+
+1. **Context Update** → Document:
+   - Recipe extraction feature
+   - Claude AI integration
+   - Content extractor architecture
+
+2. **Architecture Tracker** → Update:
+   - Add /recipes/new route to Route Map
+   - Add Recipe Extraction feature flow diagram
+   - Add changelog entry
+
+3. **Analytics** → Add:
+   - Recipe creation time-series chart
+   - Source type distribution (YouTube vs URL)
+
+4. **Testing** → Create:
+   - e2e/recipes.spec.ts tests
+   - Testing plan for extraction flow
+   - Test documentation with screenshots
+```
+
+---
+
+## Checklist
+
+After sync completes, verify:
+
+- [ ] Project documentation reflects current state of codebase
+- [ ] `docs/architecture/overview.md` has all routes and features
+- [ ] Changelog has entry for recent changes
+- [ ] Recent Changes section is up to date
+- [ ] DRY audit passed — no duplicated schemas, UI patterns, or repo logic (run /dry-audit)
+- [ ] Analytics dashboard shows relevant metrics (if applicable)
+- [ ] E2E tests exist for all user-facing features
+- [ ] Test documentation with screenshots at `docs/testing/{feature}/`
+- [ ] **Screenshots copied to `public/docs/testing/{feature}/screenshots/`** (required for docs viewer)
+- [ ] No broken tests (run `bun run test:e2e`)
+
+---
+
+## When to Skip Tasks
+
+**Skip context update if:**
+- Only fixing typos or minor bugs
+- Changes are purely internal (no user impact)
+
+**Skip architecture tracker if:**
+- No new routes added
+- No new features implemented
+- No schema changes
+- Changes are UI-only tweaks (not new pages)
+- Bug fixes or refactors
+
+**Skip DRY audit if:**
+- Changes are documentation-only
+- Changes are config/environment only
+- Bug fixes that don't add new code patterns
+
+**Skip analytics if:**
+- No schema changes
+- No new trackable data
+- Changes are UI-only
+
+**Skip testing if:**
+- Changes are documentation-only
+- Changes are config/environment only
+- Tests already exist and still pass

--- a/cf-saas-stack/skills/auth/SKILL.md
+++ b/cf-saas-stack/skills/auth/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: auth
+description: Better Auth authentication patterns and conventions for this Cloudflare Workers project
+user-invocable: false
+---
+
+# Better Auth Rules for This Project
+
+## Better Auth Overview
+- This project uses **Better Auth** (`better-auth` v1.3.34+) for authentication
+- Better Auth is configured with Drizzle ORM adapter for SQLite (Cloudflare D1)
+- Uses email/password authentication with admin plugin enabled
+- Supports Google OAuth social authentication
+- Base path for auth API: `/api/auth`
+
+## Server-Side Auth Setup
+
+### Creating Auth Instance
+- **ALWAYS** use `createAuth()` from `@/auth/server` to create auth instances
+- Auth instances must be created per-request (not cached globally)
+- Required parameters:
+  - `database`: D1Database instance from Cloudflare context
+  - `options`: Object containing:
+    - `secret`: BETTER_AUTH_SECRET from environment variables
+    - `googleClientId`: GOOGLE_CLIENT_ID from environment variables
+    - `googleClientSecret`: GOOGLE_CLIENT_SECRET from environment variables
+- Example pattern:
+```typescript
+import { createAuth } from "@/auth/server";
+
+const auth = await createAuth(context.cloudflare.env.DATABASE, {
+  secret: context.cloudflare.env.BETTER_AUTH_SECRET,
+  googleClientId: context.cloudflare.env.GOOGLE_CLIENT_ID,
+  googleClientSecret: context.cloudflare.env.GOOGLE_CLIENT_SECRET,
+});
+```
+
+### Auth Route Handler
+- Auth routes are handled at `/api/auth` via `app/routes/api/auth.$.ts`
+- Both `loader` and `action` should call `auth.handler(request)`
+
+### Session Retrieval
+- Use `auth.api.getSession({ headers })` to get current session
+- Returns `{ session, user }` or `null` if not authenticated
+- Always pass request headers for proper session resolution
+
+## Client-Side Auth
+- **ALWAYS** use `authClient` from `@/auth/client` for client-side operations
+- Client is pre-configured with base path `/api/auth` and admin plugin enabled
+- Use `authClient.signIn.email()` for login, `authClient.signUp.email()` for signup
+- Use `authClient.signOut()` for logout
+- Use `authClient.useSession()` hook for React components
+
+## tRPC Integration
+- Auth is integrated into tRPC context via `createTRPCContext`
+- Context includes `authApi` (Better Auth API) and `auth` (session data)
+- Use `protectedProcedure` for authenticated-only endpoints (guarantees `ctx.auth.user` and `ctx.auth.session`)
+- Use `adminProcedure` for admin-only endpoints (checks `user.role === "admin"`)
+
+## Database Schema
+- Better Auth uses Drizzle adapter with SQLite provider
+- Schema imported from `@/db/schema`, database connection via `getDb()` from `@/db`
+
+## Security Best Practices
+- **NEVER** expose `BETTER_AUTH_SECRET` in client-side code
+- **ALWAYS** validate authentication server-side
+- **NEVER** trust client-side auth state alone
+- Use `protectedProcedure` or `adminProcedure` for sensitive operations
+- Create auth instances per-request (not globally cached)
+- Handle `UNAUTHORIZED` (401) and `FORBIDDEN` (403) errors
+- Use tRPC error codes: `UNAUTHORIZED` and `FORBIDDEN`
+
+## Common Patterns
+
+### Checking Auth in Loaders/Actions
+```typescript
+const auth = await createAuth(env.DATABASE, env.BETTER_AUTH_SECRET);
+const session = await auth.api.getSession({ headers: request.headers });
+if (!session) {
+  throw redirect("/login");
+}
+```
+
+### Client-Side Auth State
+```typescript
+import { authClient } from "@/auth/client";
+const { data: session } = authClient.useSession();
+```

--- a/cf-saas-stack/skills/cloudflare-workflows/SKILL.md
+++ b/cf-saas-stack/skills/cloudflare-workflows/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: cloudflare-workflows
+description: Cloudflare Workflows patterns for background tasks and async processing
+user-invocable: false
+---
+
+# Cloudflare Workflows
+
+Use Cloudflare Workflows for background tasks instead of running them in request handlers.
+
+## When to Use Workflows
+- AI/LLM API calls (Gemini, Anthropic, etc.)
+- Long-running operations (> 1-2 seconds)
+- Tasks that shouldn't block user actions
+- Operations that need retry/resilience
+
+## Workflow Structure
+```typescript
+// workflows/my-task.ts
+import { WorkflowEntrypoint, type WorkflowEvent, type WorkflowStep, env } from "cloudflare:workers";
+import { getDb } from "@/db";
+
+export interface MyTaskWorkflowPayload {
+  resourceId: string;
+  userId: string;
+}
+
+export class MyTaskWorkflow extends WorkflowEntrypoint<Env, MyTaskWorkflowPayload> {
+  async run(event: WorkflowEvent<MyTaskWorkflowPayload>, step: WorkflowStep) {
+    const { resourceId, userId } = event.payload;
+
+    // Step 1: Do work (each step is retried on failure)
+    const result = await step.do("process-data", async () => {
+      return { processed: true };
+    });
+
+    // Step 2: Update database
+    await step.do("save-result", async () => {
+      const db = await getDb(this.env.DATABASE);
+      // Update record...
+    });
+
+    return { success: true };
+  }
+}
+```
+
+## Registration Checklist
+
+1. **wrangler.jsonc** - Add workflow binding:
+```json
+{ "binding": "MY_TASK_WORKFLOW", "name": "landfall-my-task-workflow", "class_name": "MyTaskWorkflow" }
+```
+
+2. **workers/app.ts** - Export workflow:
+```typescript
+export { MyTaskWorkflow } from "../workflows/my-task";
+```
+
+3. **app/trpc/index.ts** - Add to context:
+```typescript
+workflows: {
+  MyTaskWorkflow: opts.cfContext.MY_TASK_WORKFLOW,
+}
+```
+
+4. **Regenerate types**: `bun run typegen`
+
+## Triggering from tRPC
+```typescript
+try {
+  await ctx.workflows.MyTaskWorkflow.create({
+    params: { resourceId, userId: ctx.auth.user.id },
+  });
+} catch (error) {
+  log.error({ err: error }, "Failed to start workflow");
+  // Don't fail the request if workflow fails to start
+}
+```
+
+## Key Patterns
+- **Non-blocking**: User action completes immediately, workflow runs async
+- **Idempotent steps**: Each `step.do()` may retry - ensure operations are safe to repeat
+- **Error handling**: Catch workflow start errors, don't fail the user's request

--- a/cf-saas-stack/skills/context-clients/SKILL.md
+++ b/cf-saas-stack/skills/context-clients/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: context-clients
+description: Context-based client pattern for passing external service clients through request context
+user-invocable: false
+---
+
+# Context-Based Client Pattern
+
+## Overview
+External service clients (Stripe, AI, analytics, etc.) are created once at the request level and passed through context. Repositories and services receive clients as parameters rather than creating them.
+
+## Why This Pattern?
+1. **Single initialization** - Clients are created once per request, not per function call
+2. **Testability** - Easy to mock clients in tests
+3. **Configuration** - Environment variables are accessed in one place
+4. **Resource management** - Proper cleanup/shutdown of clients
+
+## Worker Entry Point
+Create clients in the Cloudflare Worker and pass to React Router context:
+```typescript
+// workers/app.ts
+export default {
+  async fetch(request, env, ctx) {
+    const auth = await createAuth(env.DATABASE, { secret: env.AUTH_SECRET });
+    const stripe = env.STRIPE_SECRET_KEY ? createStripeClient(env.STRIPE_SECRET_KEY) : null;
+    const ai = createAIClient(env.AI_API_KEY);
+    return requestHandler(request, { cloudflare: { env, ctx }, auth, stripe, ai });
+  },
+} satisfies ExportedHandler<Env>;
+```
+Run `bun typegen` to generate the `AppLoadContext` types automatically.
+
+## tRPC Context
+Pass clients from Cloudflare context to tRPC context:
+```typescript
+// app/trpc/index.ts
+export const createTRPCContext = async (opts) => {
+  const db = await getDb(opts.cfContext.DATABASE);
+  const stripe = opts.cfContext.STRIPE_SECRET_KEY ? createStripeClient(opts.cfContext.STRIPE_SECRET_KEY) : null;
+  const ai = createAIClient(opts.cfContext.AI_API_KEY);
+  return { db, stripe, ai, cfContext: opts.cfContext };
+};
+```
+
+## Using Clients in tRPC Routes
+Access clients from context, pass to repositories:
+```typescript
+export const paymentRouter = createTRPCRouter({
+  createPayment: protectedProcedure
+    .input(z.object({ amount: z.number() }))
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.stripe) {
+        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Payment system not configured" });
+      }
+      return await paymentRepository.createPayment(ctx.db, ctx.stripe, input);
+    }),
+});
+```
+
+## Repository Functions
+Repositories receive clients as parameters:
+```typescript
+// CORRECT: Receive client as parameter
+export async function createPayment(db: Database, stripe: StripeClient, input: CreatePaymentInput) {
+  const paymentIntent = await stripe.paymentIntents.create({ amount: input.amount, currency: "usd" });
+}
+
+// WRONG: Creating client inside repository
+export async function createPaymentBad(db: Database, stripeSecretKey: string, input: CreatePaymentInput) {
+  const stripe = new Stripe(stripeSecretKey); // Don't create here
+}
+```
+
+## Client Factory Functions
+Create simple factory functions in `app/lib/`:
+```typescript
+// app/lib/stripe.ts
+export function createStripeClient(secretKey: string): Stripe {
+  return new Stripe(secretKey, { apiVersion: "2024-06-20" });
+}
+```
+
+## Null Checking Pattern
+Always check for optional clients before use:
+```typescript
+if (!ctx.stripe) {
+  throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Payment system is not configured" });
+}
+await ctx.stripe.customers.create({ ... });
+```
+
+## Layer Responsibilities
+| Layer | Responsibility |
+|-------|---------------|
+| `workers/app.ts` | Create clients from env vars |
+| `app/trpc/index.ts` | Include clients in tRPC context |
+| `app/trpc/routes/*.ts` | Access clients from `ctx`, pass to repos |
+| `app/repositories/*.ts` | Receive clients as parameters |
+| `app/lib/*.ts` | Factory functions for client creation |

--- a/cf-saas-stack/skills/context-docs/SKILL.md
+++ b/cf-saas-stack/skills/context-docs/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: context-docs
+description: Documentation hierarchy and maintenance rules for context docs and architecture files
+user-invocable: false
+---
+
+# Context Documentation Maintenance
+
+## Documentation Hierarchy
+
+**Source of Truth**: `.cursor/context/` folder contains detailed documentation:
+- `api.md` - tRPC routes, auth endpoints, procedure types, error responses
+- `architecture.md` - System overview, data flow patterns, layer responsibilities
+- `high-level-architecture.md` - Living visual doc with route map, feature flows, data relationships, changelog (canonical version at `docs/architecture/overview.md`)
+- `data-models.md` - Schema, entity relationships, tables overview, migrations
+- `features.md` - Feature documentation with flow diagrams and key files
+- `integrations.md` - External services (Cloudflare, Better Auth, Stripe, PostHog)
+- `security.md` - Auth flow, session management, authorization, RBAC
+- `user-journeys.md` - User flows, admin journeys, error states
+
+**Quick Reference**: `.cursor/context.md` is a compressed index that:
+- Points agents to detailed docs in `.cursor/context/`
+- Provides compressed indices of rules and context docs
+- Contains brief overview, tech stack summary, and recent changes
+
+## When to Update
+
+### Update detailed docs when:
+- Implementing new features -> `features.md`
+- Adding API routes -> `api.md`
+- Changing architecture -> `architecture.md`
+- Modifying schema -> `data-models.md`
+- Adding integrations -> `integrations.md`
+- Changing auth/security -> `security.md`
+- New user flows -> `user-journeys.md`
+
+### Update context.md index when:
+- A context doc's scope changes
+- Adding new rules
+- Adding significant new features
+- Adding new tech stack components
+
+### Update docs/architecture/overview.md when:
+- Adding new routes (update Route Map)
+- Implementing new features (add Feature Flow section)
+- Schema changes (update Data Relationships ER diagram)
+- Architectural decisions (update System Architecture)
+- **Always add a Changelog entry with date**
+
+### Update docs/architecture/ when:
+- Updating corresponding `.cursor/context/` files (dual sync)
+- Architecture, API, schema, features, integrations, security, or user flows change
+
+### Update docs/design/design-system-overview.md when:
+- Modifying `app/app.css` (color variables, typography)
+- Adding new ShadCN components
+- Changing icon sets or spacing conventions
+
+## Pipe-Delimited Index Format (for context.md)
+```
+[Index Name]|root: path/to/files/
+|IMPORTANT: Key instruction
+|file1.ext: brief description
+|subdir/:{file-a.ext,file-b.ext,...}
+```
+
+## context.md Required Sections
+1. Agent Instructions
+2. Context Docs Index
+3. Rules Index
+4. Overview (one sentence)
+5. Tech Stack
+6. Architecture (2-4 bullets)
+7. Features (3-5 lines max each)
+8. Recent Changes (last 3-4)
+
+## Human Documentation (`docs/`)
+
+The `docs/` directory contains human-readable documentation visible in the admin docs viewer at `/admin/docs`:
+
+```
+docs/
+|-- architecture/         # System architecture docs (mirrors .cursor/context/)
+|   |-- overview.md       # Master doc: route map, feature flows, changelog
+|   |-- system.md         # System architecture (from architecture.md)
+|   |-- api.md            # API reference (from api.md)
+|   |-- data-models.md    # Data models (from data-models.md)
+|   |-- features.md       # Feature catalog (from features.md)
+|   |-- integrations.md   # Integrations (from integrations.md)
+|   |-- security.md       # Security model (from security.md)
+|   |-- user-journeys.md  # User journeys (from user-journeys.md)
+|-- design/               # Design system docs
+|   |-- design-system-overview.md  # Colors, typography, components
+|-- features/             # Feature documentation
+|-- ideas/                # Ideas and brainstorms
+|-- meetings/             # Meeting notes
+|-- plans/                # Roadmaps and plans
+|-- releases/             # Release notes
+```
+
+### Dual Documentation Pattern
+
+`.cursor/context/` files are optimized for AI agent consumption (compressed, indexed).
+`docs/architecture/` files are optimized for human reading (prose, Mermaid diagrams, frontmatter).
+
+When updating `.cursor/context/`, also update the corresponding `docs/architecture/` file.
+When making design system changes, update `docs/design/design-system-overview.md`.
+Always add a changelog entry to `docs/architecture/overview.md`.
+
+## Compression Philosophy
+- Target 80%+ reduction from verbose docs
+- Agent should quickly understand project structure and know where to look

--- a/cf-saas-stack/skills/database/SKILL.md
+++ b/cf-saas-stack/skills/database/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: database
+description: Drizzle ORM database schema patterns and conventions for SQLite/D1
+user-invocable: false
+---
+
+# Database Schema (Drizzle ORM)
+
+## Overview
+Database schemas use Drizzle ORM with SQLite. All schema definitions are in `app/db/schema.ts`.
+
+## Table Definition Pattern
+```typescript
+import { sql } from "drizzle-orm";
+import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+
+export const myTable = sqliteTable("my_table", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  description: text("description"),
+  email: text("email").notNull().unique(),
+  isActive: integer("is_active", { mode: "boolean" }).default(false).notNull(),
+  status: text("status", { enum: ["pending", "active", "completed"] }).default("pending").notNull(),
+  counter: integer("counter").default(0).notNull(),
+  metadata: text("metadata", { mode: "json" }).$type<{ key?: string; value?: number; }>(),
+  userId: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+    .notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+    .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+    .$onUpdate(() => new Date())
+    .notNull(),
+});
+
+export type MyTable = typeof myTable.$inferSelect;
+export type InsertMyTable = typeof myTable.$inferInsert;
+```
+
+## Field Patterns
+
+### Timestamps (ALWAYS include)
+```typescript
+createdAt: integer("created_at", { mode: "timestamp_ms" })
+  .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+  .notNull(),
+updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+  .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+  .$onUpdate(() => new Date())
+  .notNull(),
+```
+
+### Booleans
+Use integer with `mode: "boolean"`:
+```typescript
+isEnabled: integer("is_enabled", { mode: "boolean" }).default(false).notNull(),
+```
+
+### Enums
+Use text with enum option:
+```typescript
+status: text("status", { enum: ["pending", "active", "completed"] }).default("pending").notNull(),
+```
+
+### JSON Fields
+Use text with `mode: "json"` and `.$type<T>()`:
+```typescript
+settings: text("settings", { mode: "json" }).$type<{ notifications?: boolean; theme?: "light" | "dark"; }>(),
+```
+
+### Foreign Keys
+Always specify `onDelete` behavior:
+```typescript
+userId: text("user_id").references(() => user.id, { onDelete: "cascade" }),
+organizationId: text("organization_id").references(() => organization.id, { onDelete: "set null" }),
+```
+
+## Naming Conventions
+- **Table names:** `snake_case` in SQL
+- **Column names:** `snake_case` in SQL
+- **TypeScript variables:** `camelCase`
+
+## Generating Migrations
+```bash
+bun run db:generate
+bun run db:migrate:local
+```

--- a/cf-saas-stack/skills/docs/SKILL.md
+++ b/cf-saas-stack/skills/docs/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: docs
+description: Documentation guidelines for creating and maintaining docs folder structure
+user-invocable: false
+---
+
+# Documentation Guidelines
+
+Rules for creating and maintaining documentation in the `docs/` folder.
+
+## File Structure
+```
+docs/
+  features/   # Technical feature documentation and architecture
+  ideas/      # Brainstorming and feature ideas
+  meetings/   # Meeting notes (date-prefixed)
+  plans/      # Roadmaps and project plans
+  releases/   # Changelog and release notes
+  research/   # Competitive research and UX analysis
+  testing/    # Testing plans with screenshots
+    {feature}/
+      {feature}.md
+      screenshots/
+```
+
+## Naming Conventions
+- **meetings:** `YYYY-MM-DD-description.md`
+- **releases:** `vX.Y.Z.md` or `YYYY-MM-DD-release.md`
+- **testing:** `{feature-name}/{feature-name}.md`
+- **research:** `{topic}-research.md`
+- **features:** `{feature-name}.md` or `{feature-name}-architecture.md`
+- **others:** `kebab-case.md`
+
+## Frontmatter (REQUIRED)
+All documents MUST include YAML frontmatter with at minimum a `date` field:
+```markdown
+---
+title: Human-Readable Title
+date: 2026-01-29
+---
+```
+
+## Testing Documentation Structure
+Testing plans live in `docs/testing/` with their own screenshots folder:
+```
+docs/testing/{feature-name}/
+  {feature-name}.md      # Testing plan
+  screenshots/           # Playwright screenshots
+```
+
+### CRITICAL: Copy Screenshots to Public Folder
+Screenshots MUST also be copied to `public/docs/testing/` for the documentation viewer to display them:
+```bash
+mkdir -p public/docs/testing/{feature-name}/screenshots
+cp docs/testing/{feature-name}/screenshots/*.png public/docs/testing/{feature-name}/screenshots/
+```
+
+## Category-Specific Templates
+
+### Feature Documentation
+```markdown
+---
+title: Feature Name
+date: YYYY-MM-DD
+---
+# Feature Name
+## Overview
+## How It Works
+## Usage
+## Key Files
+```
+
+### Testing Plan
+```markdown
+# Testing Plan: {Feature Name}
+## Overview
+## Prerequisites
+## Test Scenarios
+### Scenario 1: {Happy Path}
+## UI Elements to Verify
+## Test IDs Reference
+## E2E Test Coverage
+```
+
+### Release Notes
+```markdown
+# vX.Y.Z
+## Summary
+## New Features
+## Bug Fixes
+## Breaking Changes
+```
+
+### Meeting Notes
+```markdown
+# Meeting Title
+**Date:** YYYY-MM-DD
+**Attendees:** Names
+## Agenda
+## Discussion
+## Action Items
+## Next Meeting
+```
+
+## Formatting Standards
+1. Use H1 for main title, H2 for sections, H3 for subsections
+2. Include Mermaid diagrams for complex flows
+3. Use tables for structured data
+4. Use `- [ ]` for action items
+5. Always specify language in code blocks
+
+## Best Practices
+1. Be concise: Write for clarity, not length
+2. Use visuals: Mermaid diagrams help explain complex concepts
+3. Link related docs
+4. Keep updated: Remove outdated information
+5. Screenshots in testing: Save to `docs/testing/{feature}/screenshots/` AND copy to `public/docs/testing/{feature}/screenshots/`

--- a/cf-saas-stack/skills/emails/SKILL.md
+++ b/cf-saas-stack/skills/emails/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: emails
+description: Email template patterns using Resend with type-safe generator functions
+user-invocable: false
+---
+
+# Email Templates
+
+## Overview
+Email templates are stored in `app/lib/constants/emails.ts` with type-safe generator functions. Emails are sent via Resend.
+
+## File Structure
+```
+app/lib/
+  constants/
+    index.ts        # Re-exports all constants including emails
+    emails.ts       # Email templates and generator functions
+  email.ts          # sendEmail utility function
+```
+
+## Generator Function Rules
+- **ALWAYS** store email generators in `app/lib/constants/emails.ts`
+- **ALWAYS** define a TypeScript interface for each email's parameters (e.g., `PasswordResetEmailParams`)
+- **ALWAYS** name generator functions as `generateXxxEmail(params: XxxEmailParams): string`
+- **ALWAYS** destructure params at the start of the function
+- **ALWAYS** use template literals with `${variable}` syntax (not `{{placeholder}}` replacement)
+- **ALWAYS** return a complete HTML string from each generator
+- **ALWAYS** re-export generators from `app/lib/constants/index.ts`
+- **ALWAYS** import generators from `@/lib/constants` when using them
+
+## Shared Wrapper Pattern
+- Create a private `EMAIL_WRAPPER(content: string, title: string)` function for consistent styling
+- The wrapper should include: DOCTYPE, html/head/body tags, max-width container, footer
+- Individual generators build the `content` and pass it to the wrapper
+
+## Sending Function (`app/lib/email.ts`)
+- Use Resend SDK to send emails
+- Throw `EmailError` from `@/models/errors` on failure
+- Function signature: `sendEmail(apiKey, from, to, subject, html)`
+
+## HTML Styling Rules
+- Use inline CSS only (email clients don't support external stylesheets)
+- Max width: 600px for content container
+- Use web-safe fonts with fallbacks: `-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif`
+- Primary button color: `#003362`
+- Keep important content above the fold
+
+## Usage Pattern
+```typescript
+import { generateXxxEmail } from "@/lib/constants";
+
+const html = generateXxxEmail({ name: "User", resetUrl: "https://..." });
+await sendEmail(apiKey, from, to, "Subject", html);
+```

--- a/cf-saas-stack/skills/environment-variables/SKILL.md
+++ b/cf-saas-stack/skills/environment-variables/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: environment-variables
+description: Environment variable access patterns for Cloudflare Workers (never use process.env)
+user-invocable: false
+---
+
+# Environment Variables in Cloudflare Workers
+
+**NEVER use `process.env` to access environment variables.** This project runs on Cloudflare Workers where environment variables must be accessed through the Cloudflare `Env` bindings.
+
+## Preferred Pattern: Create Client Instances in Context
+
+For external services (APIs, SDKs), create client instances in the tRPC context and pass them through:
+
+```typescript
+// app/trpc/index.ts
+export const createTRPCContext = async (opts) => {
+  const gemini = opts.cfContext.GEMINI_API_KEY
+    ? createGeminiClient(opts.cfContext.GEMINI_API_KEY)
+    : null;
+  return { db, auth, gemini };
+};
+
+// In tRPC routes - use the client instance
+export const myRouter = createTRPCRouter({
+  myProcedure: protectedProcedure.mutation(async ({ ctx }) => {
+    if (!ctx.gemini) {
+      throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Gemini not configured" });
+    }
+    await ctx.gemini.generateContent(prompt);
+  }),
+});
+```
+
+## Adding New External Services
+1. Add the API key to `.env` for local development
+2. Run `bunx wrangler types` to regenerate `worker-configuration.d.ts`
+3. Create a client factory function in `app/lib/` (e.g., `createMyServiceClient`)
+4. Initialize the client in `createTRPCContext` and add to context
+5. For production, set secrets via `wrangler secret put VARIABLE_NAME`
+
+## Where Clients are Created
+
+### 1. tRPC Context (`app/trpc/index.ts`)
+For use in tRPC routes via `ctx`.
+
+### 2. Workers Entry (`workers/app.ts`)
+For use in React Router loaders/actions via `context`.
+
+## Current Available Clients
+
+### In tRPC Routes (`ctx.`)
+- `ctx.db` - Drizzle database instance
+- `ctx.auth` - Better Auth session/user
+- `ctx.gemini` - Google Gemini AI client (nullable)
+
+### In React Router Loaders (`context.`)
+- `context.trpc` - tRPC caller for server-side API calls
+- `context.auth` - Better Auth instance
+- `context.gemini` - Google Gemini AI client (nullable)
+- `context.cloudflare.env` - Raw env (avoid using directly)

--- a/cf-saas-stack/skills/errors/SKILL.md
+++ b/cf-saas-stack/skills/errors/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: errors
+description: Custom error class patterns for consistent error handling across repositories
+user-invocable: false
+---
+
+# Custom Error Classes
+
+## Overview
+Custom error classes provide consistent error handling across repositories and services.
+
+## Base Error Class Pattern
+```typescript
+export class DomainError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly statusCode: number = 500,
+    public readonly context?: Record<string, unknown>
+  ) {
+    super(message);
+    this.name = "DomainError";
+    Object.setPrototypeOf(this, DomainError.prototype);
+  }
+}
+```
+
+## Derived Error Pattern
+```typescript
+export class NotFoundError extends RepositoryError {
+  constructor(
+    public readonly entity: string,
+    public readonly identifier: string | Record<string, unknown>,
+    message?: string
+  ) {
+    const defaultMessage = typeof identifier === "string"
+      ? `${entity} not found: ${identifier}`
+      : `${entity} not found`;
+    super(message || defaultMessage, "NOT_FOUND", 404, { entity, identifier });
+    this.name = "NotFoundError";
+    Object.setPrototypeOf(this, NotFoundError.prototype);
+  }
+}
+```
+
+## Common Repository Errors
+- `RepositoryError` - Base class
+- `NotFoundError` - Record not found (404)
+- `CreationError` - Insert failed (500)
+- `UpdateError` - Update failed (500)
+- `DeletionError` - Delete failed (500)
+- `QueryError` - Query failed (500)
+- `ValidationError` - Business rule violation (400)
+
+## Usage in Repositories
+```typescript
+import { NotFoundError, UpdateError } from "@/models/errors";
+
+export async function getById(db: Database, id: string) {
+  try {
+    const result = await db.select().from(table).where(eq(table.id, id));
+    if (result.length === 0) {
+      throw new NotFoundError("entity", id);
+    }
+    return result[0];
+  } catch (error) {
+    if (error instanceof NotFoundError) throw error;
+    throw new QueryError("entity", "Failed to retrieve", error);
+  }
+}
+```
+
+## Error Codes Convention
+- `NOT_FOUND` - Resource doesn't exist (404)
+- `CREATION_FAILED` - Insert failed (500)
+- `UPDATE_FAILED` - Update failed (500)
+- `DELETION_FAILED` - Delete failed (500)
+- `VALIDATION_FAILED` - Business rule violation (400)
+
+## Important Rules
+- Always use `Object.setPrototypeOf` for proper `instanceof` checks
+- Preserve original errors for debugging
+- Re-throw custom errors, wrap unexpected ones

--- a/cf-saas-stack/skills/feature-flags/SKILL.md
+++ b/cf-saas-stack/skills/feature-flags/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: feature-flags
+description: PostHog feature flag evaluation patterns with server-side loading
+user-invocable: false
+---
+
+# Feature Flags with PostHog
+
+## Overview
+- This project uses **PostHog** for feature flag management
+- Feature flags are evaluated **server-side** in loaders for performance and security
+- Flag values are passed to components via loader data
+
+## File Structure
+- `app/posthog/feature-flags.ts` - Flag key constants and TypeScript types
+- `app/posthog/server.ts` - Server-side PostHog client and flag evaluation
+- `app/posthog/provider.tsx` - Client-side PostHog provider and hooks
+- `app/posthog/index.ts` - Re-exports
+
+## Defining Feature Flags
+
+### Step 1: Add Flag Key to Constants
+```typescript
+// app/posthog/feature-flags.ts
+export const FEATURE_FLAGS = {
+  MY_NEW_FLAG: "feature-my-new-flag",
+} as const;
+```
+
+### Step 2: Add to FeatureFlags Interface
+```typescript
+export interface FeatureFlags {
+  myNewFlagEnabled: boolean;
+}
+```
+
+### Step 3: Set Default Value
+```typescript
+export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
+  myNewFlagEnabled: false,
+};
+```
+
+## Server-Side Flag Evaluation
+**ALWAYS** evaluate feature flags server-side in route loaders using `context.posthog`:
+```typescript
+import { getFeatureFlag } from "@/posthog/server";
+import { FEATURE_FLAGS } from "@/posthog/feature-flags";
+
+export async function loader({ request, context }: Route.LoaderArgs) {
+  const session = await context.auth.api.getSession({ headers: request.headers });
+  const myFeatureEnabled = session?.user
+    ? await getFeatureFlag(context.posthog, session.user.id, FEATURE_FLAGS.MY_NEW_FLAG, false)
+    : false;
+  return { myFeatureEnabled };
+}
+```
+
+### Key Points
+- **ALWAYS** use `context.posthog` - it's already initialized in `workers/app.ts`
+- **NEVER** call `createPostHogClient()` in loaders
+- **ALWAYS** pass `session.user.id` as the `distinctId`
+- **ALWAYS** provide a default value (typically `false`)
+- **NEVER** evaluate flags client-side for security-sensitive features
+
+## Using Flags in Components
+```typescript
+export default function MyPage() {
+  const { myFeatureEnabled } = useLoaderData<typeof loader>();
+  return (
+    <div>
+      {myFeatureEnabled && <NewFeatureComponent />}
+    </div>
+  );
+}
+```
+
+## Client-Side Analytics
+```typescript
+import { useAnalytics } from "@/posthog";
+function MyComponent() {
+  const { trackEvent } = useAnalytics();
+  const handleClick = () => { trackEvent('button_clicked', { buttonName: 'signup' }); };
+}
+```
+
+## Naming Conventions
+- Flag keys in PostHog: `feature-{feature-name}` or `{TICKET-ID}-{Feature-Name}`
+- TypeScript constants: `SCREAMING_SNAKE_CASE`
+- Interface properties: `camelCaseEnabled`
+
+## Cleanup
+- Remove flag checks after feature is fully rolled out
+- Update `FEATURE_FLAGS`, `FeatureFlags` interface, and `DEFAULT_FEATURE_FLAGS`
+- Search codebase for all usages before removing

--- a/cf-saas-stack/skills/i18n/SKILL.md
+++ b/cf-saas-stack/skills/i18n/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: i18n
+description: Internationalization patterns using remix-i18next and react-i18next
+user-invocable: false
+---
+
+# i18n (Internationalization) Guidelines
+
+## Overview
+This project uses **remix-i18next** with **i18next** and **react-i18next** for internationalization. Translations are bundled (not loaded from filesystem) for Cloudflare Workers compatibility.
+
+## Core Rules
+
+### Never hardcode user-facing strings
+- All user-facing text must use `t()` from `useTranslation()`
+- Use semantic dot-notation keys: `t("dashboard.total_users")` not `t("totalUsers")`
+- Group keys by namespace: `common`, `auth`, `admin`, `home`, `validation`
+
+### Always export `handle` with i18n namespaces on route files
+```typescript
+export const handle = { i18n: ["admin"] };
+```
+
+### Translation file organization
+- Files live in `app/locales/{lng}/{namespace}.json`
+- Each namespace maps to a JSON file
+- Keys use snake_case with dot notation for nesting
+
+### Using translations in components
+```typescript
+import { useTranslation } from "react-i18next";
+
+function MyComponent() {
+  const { t } = useTranslation("namespace");
+  return <h1>{t("section.key")}</h1>;
+}
+```
+
+### Using translations in loaders/meta
+```typescript
+import { i18nServer } from "@/i18n/i18n.server";
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const t = await i18nServer.getFixedT(request, "namespace");
+  return { title: t("page.title") };
+}
+```
+
+### Interpolation
+```json
+{ "greeting": "Hello, {{name}}!" }
+```
+```typescript
+t("greeting", { name: user.name })
+```
+
+### Pluralization
+```json
+{ "items": "{{count}} item", "items_other": "{{count}} items" }
+```
+
+### Zod validation errors
+- Use the custom error map from `app/lib/zod-i18n.ts`
+- Validation keys live in `app/locales/en/validation.json`
+
+## How to Add a New Language
+
+1. Create translation files: `app/locales/{lng}/common.json`, `auth.json`, etc.
+2. Add the locale code to `supportedLngs` in `app/i18n/i18n.ts`
+3. Add the language label to `languageLabels` in `app/components/language-switcher.tsx`
+4. Add the date-fns locale mapping in `app/lib/date-utils.ts`
+5. Test with `bun run dev` and navigate to `/{lng}/` prefix routes
+
+## Key Files
+- `app/i18n/i18n.ts` — Shared config (supported languages, namespaces)
+- `app/i18n/i18n.server.ts` — Server-side RemixI18Next instance
+- `app/i18n/i18n.client.ts` — Client-side i18next initialization
+- `app/i18n/i18n.d.ts` — TypeScript type augmentation for translation keys
+- `app/locales/en/*.json` — English translation files
+- `app/components/language-switcher.tsx` — Language switcher component
+- `app/lib/zod-i18n.ts` — Zod error map for translated validation
+- `app/lib/date-utils.ts` — date-fns locale helper

--- a/cf-saas-stack/skills/modals/SKILL.md
+++ b/cf-saas-stack/skills/modals/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: modals
+description: Modal component patterns using ShadCN Dialog with tRPC mutations
+user-invocable: false
+---
+
+# Modal Components
+
+## Overview
+Modal components follow a consistent pattern using ShadCN Dialog components with tRPC mutations for data operations.
+
+## File Naming
+Use the naming pattern `{feature}-modal.tsx` (e.g., `edit-user-modal.tsx`, `create-item-modal.tsx`)
+
+## Props Interface Pattern
+```typescript
+interface FeatureModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess?: () => void;
+  entityId?: string;
+  mode?: "create" | "edit";
+}
+```
+
+## Component Structure
+```typescript
+import { useState, useEffect } from "react";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Loader2 } from "lucide-react";
+import { api } from "@/trpc/client";
+import { toast } from "sonner";
+
+export function FeatureModal({ open, onOpenChange, entityId, onSuccess }: FeatureModalProps) {
+  // 1. Local form state
+  const [fieldValue, setFieldValue] = useState("");
+
+  // 2. tRPC utilities for cache invalidation
+  const utils = api.useUtils();
+
+  // 3. Query for existing data (if editing)
+  const { data, isLoading } = api.route.getData.useQuery(
+    { entityId },
+    { enabled: open && !!entityId }
+  );
+
+  // 4. Effect to populate form when data loads
+  useEffect(() => {
+    if (open && data) setFieldValue(data.field ?? "");
+  }, [open, data]);
+
+  // 5. Effect to reset form when modal closes
+  useEffect(() => {
+    if (!open) setFieldValue("");
+  }, [open]);
+
+  // 6. Mutation
+  const mutation = api.route.save.useMutation({
+    onSuccess: () => {
+      toast.success("Saved successfully");
+      utils.route.getData.invalidate();
+      onOpenChange(false);
+      onSuccess?.();
+    },
+    onError: (error) => toast.error(error.message || "Failed to save"),
+  });
+
+  // 7. Submit handler
+  const handleSave = async () => {
+    await mutation.mutateAsync({ entityId, field: fieldValue.trim() });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px]" data-testid="feature-modal">
+        <DialogHeader><DialogTitle>Modal Title</DialogTitle></DialogHeader>
+        {isLoading ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="size-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : (
+          <div className="flex flex-col gap-4">{/* Form fields */}</div>
+        )}
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={mutation.isPending}>Cancel</Button>
+          <Button onClick={handleSave} disabled={mutation.isPending}>
+            {mutation.isPending ? (<><Loader2 className="size-4 animate-spin mr-2" />Saving...</>) : "Save"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+## Key Patterns
+- Show spinner when fetching existing data
+- Disable buttons when mutation is pending
+- Use `useState` for form fields, populate from query data in `useEffect`
+- Reset form state when modal closes
+- Call `utils.routeName.queryName.invalidate()` after successful mutation
+- Add `data-testid` to modal content and important elements
+- Use `toast.error()` in mutation `onError` callback
+
+## Multi-Purpose Modals
+```typescript
+interface MultiPurposeModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mode: "create" | "edit";
+}
+export function MultiPurposeModal({ mode, ...props }: MultiPurposeModalProps) {
+  const title = mode === "edit" ? "Edit Item" : "Create Item";
+  const buttonText = mode === "edit" ? "Save" : "Create";
+}
+```

--- a/cf-saas-stack/skills/models/SKILL.md
+++ b/cf-saas-stack/skills/models/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: models
+description: Zod schema patterns for data models and runtime validation
+user-invocable: false
+---
+
+# Models and Types (Zod Schemas)
+
+## Overview
+Data models use Zod for runtime validation and TypeScript type inference.
+
+## Basic Pattern
+```typescript
+import { z } from "zod";
+
+// 1. Define schema
+export const entitySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  status: z.enum(["active", "inactive"]),
+});
+
+// 2. Export inferred type
+export type Entity = z.infer<typeof entitySchema>;
+```
+
+## Naming Conventions
+- **Schema:** `camelCaseSchema` (e.g., `userStatusSchema`)
+- **Type:** `PascalCase` (e.g., `UserStatus`)
+
+## Common Patterns
+
+### Enums
+```typescript
+export const statusSchema = z.enum(["pending", "active", "completed"]);
+export type Status = z.infer<typeof statusSchema>;
+```
+
+### Objects
+```typescript
+export const userSchema = z.object({
+  id: z.string(),
+  email: z.string().email(),
+  age: z.number().int().positive().optional(),
+});
+export type User = z.infer<typeof userSchema>;
+```
+
+### Optional/Nullable
+```typescript
+export const profileSchema = z.object({
+  bio: z.string().optional(),       // string | undefined
+  avatar: z.string().nullable(),    // string | null
+  website: z.string().nullish(),    // string | null | undefined
+});
+```
+
+### Defaults
+```typescript
+export const settingsSchema = z.object({
+  theme: z.enum(["light", "dark"]).default("light"),
+  pageSize: z.number().default(10),
+});
+```
+
+## Composing Schemas
+```typescript
+export const addressSchema = z.object({ street: z.string(), city: z.string() });
+export const companySchema = z.object({ name: z.string(), address: addressSchema });
+export type Company = z.infer<typeof companySchema>;
+```
+
+## Usage with tRPC
+```typescript
+import { z } from "zod/v4";
+import { statusSchema } from "@/models/types";
+
+export const router = createTRPCRouter({
+  update: protectedProcedure
+    .input(z.object({ id: z.string(), status: statusSchema }))
+    .mutation(async ({ input }) => { ... }),
+});
+```
+
+**Important:** In tRPC routes, import Zod as `import { z } from "zod/v4"`. In models, use `import { z } from "zod"`.
+
+## Runtime Validation
+```typescript
+function parseData(data: unknown) {
+  const result = entitySchema.safeParse(data);
+  if (!result.success) {
+    console.error(result.error.flatten());
+    return null;
+  }
+  return result.data; // Fully typed
+}
+```

--- a/cf-saas-stack/skills/playwright-tests/SKILL.md
+++ b/cf-saas-stack/skills/playwright-tests/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: playwright-tests
+description: Playwright E2E testing rules including self-contained tests and element selection
+user-invocable: false
+---
+
+# Playwright E2E Testing Rules
+
+## Test File Structure
+- Place tests in `e2e/` directory with `*.spec.ts` naming pattern
+- Use `@playwright/test` framework
+- Group related tests using `test.describe()` blocks
+- Use `test.beforeEach()` for common setup (e.g., navigation, login)
+
+## Self-Contained Tests (CRITICAL)
+- **Every test file MUST include a login step** — never assume an active session exists
+- **Every test file MUST seed its own data** — never depend on pre-existing data in the database
+  - Use API calls, UI flows, or direct DB setup to create the data each test needs
+  - Tests should be runnable on a fresh database with only the test admin user
+- **Tests MUST clean up after themselves** when they create data that could interfere with other tests
+- The login step goes in `test.beforeEach()` so every test starts authenticated
+- Data seeding can happen in `test.beforeEach()` or at the start of individual tests depending on scope
+
+### Login + Seed Pattern
+```typescript
+test.beforeEach(async ({ page }) => {
+  // 1. Always login first
+  await page.goto("/login");
+  await page.fill('[data-testid="email"]', "admin@test.local");
+  await page.fill('[data-testid="password"]', "TestAdmin123!");
+  await page.click('[data-testid="login-button"]');
+  await page.waitForURL("/dashboard");
+
+  // 2. Seed data required by the tests (example: create a research)
+  // Use UI flows or API calls to ensure required data exists
+});
+```
+
+## Element Selection (CRITICAL)
+- **ALWAYS prefer locating elements by id or data-testid attributes to avoid duplication errors**
+  - Use `getByTestId()` for elements with `data-testid` attributes
+  - Use `locator('#element-id')` for elements with `id` attributes
+  - Avoid `getByLabel()` and `getByText()` as labels and text can be duplicated
+  - Only use semantic selectors (e.g., `getByRole`) when ids are not available
+
+## Test Quality
+- Write comprehensive tests that verify:
+  - UI components render correctly
+  - User interactions work as expected
+  - Form submissions and validations
+  - Navigation and routing behavior
+  - Error states and edge cases
+- Use descriptive test names that clearly indicate what is being tested
+- Use `expect()` assertions to verify expected behavior
+
+## Test Credentials
+- Test admin user: `admin@test.local` / `TestAdmin123!` (role: admin)
+- These are for **local development only**
+- Better Auth requires users to be created through the API (not direct DB insert)
+- Database name: `version-two-db`
+
+## Login Flow in Tests
+See the "Self-Contained Tests" section above for the required login + seed pattern.
+
+## Data-TestId Convention
+```tsx
+<Button data-testid="submit-form">Submit</Button>
+<Input data-testid="search-input" />
+<TableRow data-testid={`row-${item.id}`}>
+<Dialog data-testid="confirm-modal">
+<form data-testid="edit-profile-form">
+```
+
+## Test Categories
+1. **Smoke Tests** - Critical paths that must always work
+2. **Feature Tests** - Complete feature workflows
+3. **Regression Tests** - Previously broken scenarios
+4. **Edge Case Tests** - Boundary conditions and unusual inputs
+
+## Running Tests
+- `bunx playwright test` - Run all e2e tests
+- `bunx playwright test e2e/some-test.spec.ts` - Run a single test file

--- a/cf-saas-stack/skills/repository-pattern/SKILL.md
+++ b/cf-saas-stack/skills/repository-pattern/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: repository-pattern
+description: Repository pattern for data access with layered architecture
+user-invocable: false
+---
+
+# Repository Pattern
+
+## Overview
+Data access follows a layered architecture:
+```
+Client Components -> tRPC Hooks -> tRPC Routes -> Repositories -> Database
+Server Loaders -> tRPC Caller -> tRPC Routes -> Repositories -> Database
+```
+
+## Repository Layer
+Repositories are pure functions that handle database operations.
+
+### Structure
+```typescript
+// app/repositories/user.ts
+import { eq } from "drizzle-orm";
+import { user } from "@/db/schema";
+import { NotFoundError, CreationError, UpdateError } from "@/models/errors";
+import type { Context } from "@/trpc";
+
+type Database = Context["db"];
+
+interface CreateUserInput { name: string; email: string; }
+interface GetUserInput { userId: string; }
+
+export async function createUser(db: Database, input: CreateUserInput) {
+  try {
+    const id = crypto.randomUUID();
+    const result = await db.insert(user).values({ id, ...input }).returning();
+    return result[0];
+  } catch (error) {
+    throw new CreationError("user", "Failed to create user", error);
+  }
+}
+
+export async function getUser(db: Database, input: GetUserInput) {
+  try {
+    const result = await db.select().from(user).where(eq(user.id, input.userId)).limit(1);
+    if (result.length === 0) throw new NotFoundError("user", input.userId);
+    return result[0];
+  } catch (error) {
+    if (error instanceof NotFoundError) throw error;
+    throw new UpdateError("user", "Failed to retrieve user", error);
+  }
+}
+```
+
+### Rules
+- **Location:** `app/repositories/{entity}.ts`
+- **First parameter:** Always `db: Database`
+- **Input:** Use typed interfaces, not raw parameters
+- **Errors:** Throw custom error classes from `@/models/errors`
+- **No context access:** Pass data explicitly, don't access ctx or session
+- **No tRPC imports:** Keep repositories framework-agnostic
+
+## tRPC Router Layer
+```typescript
+// app/trpc/routes/user.ts
+import { z } from "zod/v4";
+import { createTRPCRouter, protectedProcedure, adminProcedure } from "..";
+import * as userRepository from "@/repositories/user";
+
+export const userRouter = createTRPCRouter({
+  getUser: protectedProcedure
+    .input(z.object({ userId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      return await userRepository.getUser(ctx.db, input);
+    }),
+  createUser: adminProcedure
+    .input(z.object({ name: z.string().min(1), email: z.string().email() }))
+    .mutation(async ({ ctx, input }) => {
+      return await userRepository.createUser(ctx.db, input);
+    }),
+  updateProfile: protectedProcedure
+    .input(z.object({ name: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      return await userRepository.updateUser(ctx.db, { userId: ctx.auth.user.id, ...input });
+    }),
+});
+```
+
+### Register Router
+```typescript
+// app/trpc/router.ts
+import { userRouter } from "./routes/user";
+export const appRouter = createTRPCRouter({ user: userRouter });
+export type AppRouter = typeof appRouter;
+```
+
+### Router Rules
+- **Location:** `app/trpc/routes/{entity}.ts`
+- **Import pattern:** `import * as userRepository from "@/repositories/user"`
+- **Validation:** Use Zod schemas for all inputs
+- **Procedures:** Use `publicProcedure`, `protectedProcedure`, or `adminProcedure`
+- **Database:** Pass `ctx.db` as first argument to repositories
+- **Errors:** Let repository errors bubble up
+
+## Key Principles
+1. Separation: Repositories = data, Routes = validation/auth, Components = UI
+2. Type safety: Zod for runtime, TypeScript for compile-time
+3. Error bubbling: Throw in repos, let tRPC handle formatting
+4. No leaky abstractions: Repositories don't know about HTTP or tRPC

--- a/cf-saas-stack/skills/routes/SKILL.md
+++ b/cf-saas-stack/skills/routes/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: routes
+description: React Router route layout patterns with server-side loaders
+user-invocable: false
+---
+
+# Route Layouts (React Router)
+
+## Overview
+Routes use React Router with server-side loaders for data fetching and authentication.
+
+## File Naming
+- `_layout.tsx` - Shared layout wrapper
+- `_index.tsx` - Index route for directory
+- `resource.$id.tsx` - Dynamic route with parameter
+
+## Layout Pattern
+```typescript
+import { Outlet, redirect } from "react-router";
+import type { Route } from "./+types/_layout";
+
+export async function loader({ request, context }: Route.LoaderArgs) {
+  const session = await context.auth.api.getSession({ headers: request.headers });
+  if (!session) return redirect("/login");
+  const data = await context.trpc.route.getData();
+  return { user: session.user, data };
+}
+
+export default function Layout({ loaderData }: Route.ComponentProps) {
+  const { user, data } = loaderData;
+  return (
+    <div>
+      <nav>{/* Navigation */}</nav>
+      <main><Outlet /></main>
+    </div>
+  );
+}
+```
+
+## Page Pattern
+```typescript
+import type { Route } from "./+types/page";
+
+export async function loader({ request, context, params }: Route.LoaderArgs) {
+  const session = await context.auth.api.getSession({ headers: request.headers });
+  if (!session) return redirect("/login");
+  const item = await context.trpc.route.getById({ id: params.id });
+  return { item };
+}
+
+export default function Page({ loaderData }: Route.ComponentProps) {
+  const { item } = loaderData;
+  return <div>{/* Page content */}</div>;
+}
+```
+
+## Key Patterns
+
+### Authentication Check
+Always check session at the start of loaders:
+```typescript
+const session = await context.auth.api.getSession({ headers: request.headers });
+if (!session) return redirect("/login");
+```
+
+### Parallel Data Fetching
+```typescript
+const [items, settings] = await Promise.all([
+  context.trpc.items.list(),
+  context.trpc.settings.get(),
+]);
+```
+
+### Feature Flag Evaluation
+```typescript
+const featureEnabled = await getFeatureFlag(context.posthog, session.user.id, FEATURE_FLAGS.MY_FEATURE, false);
+return { featureEnabled };
+```
+
+### Type Safety
+Use generated types from `+types/` directory:
+```typescript
+import type { Route } from "./+types/page";
+export async function loader({ params }: Route.LoaderArgs) { ... }
+export default function Page({ loaderData }: Route.ComponentProps) { ... }
+```
+
+### Client-Side Navigation
+```typescript
+import { useNavigate, Link } from "react-router";
+function Component() {
+  const navigate = useNavigate();
+  return (
+    <>
+      <Link to="/dashboard">Dashboard</Link>
+      <button onClick={() => navigate("/settings")}>Settings</button>
+    </>
+  );
+}
+```

--- a/cf-saas-stack/skills/stripe/SKILL.md
+++ b/cf-saas-stack/skills/stripe/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: stripe
+description: Stripe integration guidelines for payment processing via context-based client
+user-invocable: false
+---
+
+# Stripe Integration Guidelines
+
+## Stripe Client Usage
+
+**NEVER create the Stripe client inside repositories or service functions.**
+
+The Stripe client is created once in the tRPC context (`app/trpc/index.ts`) and is available as `ctx.stripe`. Always pass the Stripe client from context to repository functions.
+
+### Correct Pattern
+```typescript
+// In tRPC route
+.mutation(async ({ ctx, input }) => {
+  if (!ctx.stripe) {
+    throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Payment system is not configured." });
+  }
+  return await someRepository.doStripeOperation(ctx.db, input.someId, ctx.stripe);
+});
+
+// In repository
+export async function doStripeOperation(db: Database, someId: string, stripe: StripeClient) {
+  const customer = await stripe.customers.retrieve(customerId);
+}
+```
+
+### Incorrect Pattern (NEVER do this)
+```typescript
+// DON'T create client in repositories
+import { createStripeClient } from "@/lib/stripe";
+export async function doStripeOperation(db: Database, someId: string, stripeSecretKey: string) {
+  const stripe = createStripeClient(stripeSecretKey); // DON'T
+}
+```
+
+## Type Definitions
+```typescript
+import type Stripe from "stripe";
+type StripeClient = Stripe;
+export async function someFunction(db: Database, stripe: StripeClient) { ... }
+```
+
+## Context Setup
+The Stripe client is initialized in `app/trpc/index.ts`:
+```typescript
+const stripe = opts.cfContext.STRIPE_SECRET_KEY ? createStripeClient(opts.cfContext.STRIPE_SECRET_KEY) : null;
+```
+Always check for null before using: `if (!ctx.stripe) { throw new TRPCError({ ... }); }`
+
+## File Locations
+- **Stripe utilities**: `app/lib/stripe.ts` - Low-level Stripe helpers
+- **Payment service**: `app/services/payment-trigger.ts` - Payment triggering logic
+- **Organization repository**: `app/repositories/organization.ts` - Organization + Stripe customer operations
+- **Payment repository**: `app/repositories/payment.ts` - Payment record operations
+
+## Stripe Webhook Handling
+For webhook handlers that don't have tRPC context, use `createStripeClient` directly since there's no context available. This is the **only exception** to the context-based client rule.

--- a/cf-saas-stack/skills/structured-output/SKILL.md
+++ b/cf-saas-stack/skills/structured-output/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: structured-output
+description: Structured JSON output patterns for Gemini and Claude AI APIs
+user-invocable: false
+---
+
+# Structured Output with AI APIs
+
+**ALWAYS use structured JSON output** instead of prompting for JSON and parsing responses manually. This guarantees valid JSON matching your schema.
+
+## Gemini (Google)
+
+### Package
+```typescript
+// CORRECT - Use the unified SDK
+import { GoogleGenAI, Type, type Schema } from "@google/genai";
+
+// WRONG - Deprecated package
+import { GoogleGenerativeAI } from "@google/generative-ai";
+```
+
+### Current Model
+```typescript
+const MODEL = "gemini-3-flash-preview";  // Fast, cost-effective
+const MODEL = "gemini-3-pro-preview";    // More powerful
+```
+
+### Structured Output Pattern
+```typescript
+import { GoogleGenAI, Type, type Schema } from "@google/genai";
+
+const mySchema: Schema = {
+  type: Type.OBJECT,
+  properties: {
+    title: { type: Type.STRING, description: "The title" },
+    count: { type: Type.INTEGER, description: "The count", nullable: true },
+    items: {
+      type: Type.ARRAY,
+      items: {
+        type: Type.OBJECT,
+        properties: {
+          name: { type: Type.STRING },
+          value: { type: Type.NUMBER, nullable: true },
+        },
+        required: ["name"],
+      },
+    },
+  },
+  required: ["title", "items"],
+};
+
+const response = await client.models.generateContent({
+  model: "gemini-3-flash-preview",
+  contents: prompt,
+  config: {
+    responseMimeType: "application/json",
+    responseSchema: mySchema,
+  },
+});
+const result = JSON.parse(response.text ?? "");
+```
+
+### Type Enum Values
+- `Type.STRING`, `Type.INTEGER`, `Type.NUMBER`, `Type.BOOLEAN`, `Type.OBJECT`, `Type.ARRAY`
+
+### Schema Tips
+- Use `nullable: true` for optional fields that can be null
+- Use `required: [...]` to specify mandatory fields
+- Add `description` to help the model understand field purpose
+
+## Claude (Anthropic)
+
+### Structured Output via Tool Use
+```typescript
+import Anthropic from "@anthropic-ai/sdk";
+
+const extractionTool = {
+  name: "extract_data",
+  description: "Extract structured data from content",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      title: { type: "string", description: "The title" },
+      items: { type: "array", items: { type: "object", properties: { name: { type: "string" }, value: { type: "number" } }, required: ["name"] } },
+    },
+    required: ["title", "items"],
+  },
+};
+
+const response = await client.messages.create({
+  model: "claude-sonnet-4-20250514",
+  max_tokens: 1024,
+  tools: [extractionTool],
+  tool_choice: { type: "tool", name: "extract_data" },
+  messages: [{ role: "user", content: prompt }],
+});
+const toolUse = response.content.find((block) => block.type === "tool_use");
+const result = toolUse?.input;
+```
+
+## Best Practices
+1. Always use structured output - Don't ask for JSON in prompts and parse manually
+2. Define TypeScript interfaces to match your schema for type safety
+3. Use descriptive field descriptions
+4. Mark nullable fields explicitly
+5. Keep schemas focused - one schema per extraction task

--- a/cf-saas-stack/skills/test-credentials/SKILL.md
+++ b/cf-saas-stack/skills/test-credentials/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: test-credentials
+description: Test credentials and setup instructions for local browser testing
+user-invocable: false
+---
+
+# Test Credentials for Browser Testing
+
+When testing authenticated pages locally, use these credentials:
+
+## Test Admin User
+| Field    | Value              |
+|----------|-------------------|
+| Email    | `admin@test.local` |
+| Password | `TestAdmin123!`    |
+| Role     | `admin`            |
+
+## Setup (First Time or After DB Reset)
+
+The test admin must be created through the sign-up flow, then upgraded:
+
+### Option 1: Automated via Playwright
+1. Navigate to http://localhost:5173/sign-up
+2. Fill form with Name: "Test Admin", Email: "admin@test.local", Password: "TestAdmin123!", Confirm Password: "TestAdmin123!"
+3. Click Sign up
+4. Run SQL to upgrade: `UPDATE user SET role = 'admin', email_verified = 1 WHERE email = 'admin@test.local';`
+
+### Option 2: Manual SQL After Sign-Up
+```bash
+bunx wrangler d1 execute version-two-db --local --command "UPDATE user SET role = 'admin', email_verified = 1 WHERE email = 'admin@test.local';"
+```
+
+## Login Flow for Testing
+1. Navigate to `http://localhost:5173/login`
+2. Enter email: `admin@test.local`
+3. Enter password: `TestAdmin123!`
+4. Click Login
+5. Verify redirect to dashboard
+
+## Cleanup (If User Already Exists)
+```bash
+bunx wrangler d1 execute version-two-db --local --command "DELETE FROM account WHERE user_id IN (SELECT id FROM user WHERE email = 'admin@test.local'); DELETE FROM session WHERE user_id IN (SELECT id FROM user WHERE email = 'admin@test.local'); DELETE FROM user WHERE email = 'admin@test.local';"
+```
+
+## Important Notes
+- These credentials are for **local development only**
+- Better Auth requires users to be created through the API (not direct DB insert)
+- The user has `role: admin` so all admin pages are accessible
+- Database name: `version-two-db` (check wrangler.jsonc if different)

--- a/cf-saas-stack/skills/testing-workflow/SKILL.md
+++ b/cf-saas-stack/skills/testing-workflow/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: testing-workflow
+description: Testing workflow for generating testing plans, verification, and E2E tests
+user-invocable: false
+---
+
+# Testing Workflow
+
+After implementing a plan or feature, follow this workflow to generate a testing plan, verify with Playwright, fix issues, and write an e2e test.
+
+## Step 1: Generate Testing Plan
+
+Create a testing plan folder at:
+```
+docs/testing/{feature-name}/
+  {feature-name}.md      # Testing plan document
+  screenshots/           # Playwright screenshots
+```
+
+### Testing Plan Template
+```markdown
+# Testing Plan: {Feature Name}
+
+## Overview
+Brief description of what was implemented.
+
+## Prerequisites
+- [ ] Development server running
+- [ ] Database seeded with test data
+- [ ] Test user credentials available
+
+## Test Scenarios
+### Scenario 1: {Happy Path}
+**Description:** ...
+**Steps:** ...
+**Expected Result:** ...
+**Screenshot:** ![Description](./screenshots/scenario-1.png)
+
+## UI Elements to Verify
+## API/Data Verification
+## Accessibility Checks
+## Test IDs Reference
+## E2E Test Coverage
+Test file: `e2e/{feature-name}.spec.ts`
+```
+
+## Step 2: Manual Verification
+
+Use Playwright to manually verify each scenario. Pattern:
+1. Navigate to the page
+2. Take snapshot to get element references
+3. Interact with elements (click, type)
+4. Snapshot to verify state changes
+5. Take screenshot for documentation
+
+## Step 3: Fix Issues Found
+
+1. Document the issue in the testing plan
+2. Fix the code following the repository pattern:
+   - Repository layer for data issues
+   - tRPC route for API issues
+   - Component for UI issues
+3. Re-verify the specific scenario
+
+## Step 4: Write E2E Test
+
+Create test file at `e2e/{feature-name}.spec.ts`:
+
+```typescript
+import { test, expect } from "@playwright/test";
+
+test.describe("{Feature Name}", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/login");
+    await page.fill('[data-testid="email"]', "admin@test.local");
+    await page.fill('[data-testid="password"]', "TestAdmin123!");
+    await page.click('[data-testid="login-button"]');
+    await page.waitForURL("/dashboard");
+  });
+
+  test("should {happy path}", async ({ page }) => {
+    await page.goto("/{feature-path}");
+    await page.click('[data-testid="{element}"]');
+    await expect(page.locator('[data-testid="{result}"]')).toBeVisible();
+  });
+});
+```
+
+### Data-TestId Convention
+```tsx
+<Button data-testid="submit-form">Submit</Button>
+<Input data-testid="search-input" />
+<TableRow data-testid={`row-${item.id}`}>
+<Dialog data-testid="confirm-modal">
+```
+
+## Checklist Before Marking Complete
+- [ ] Testing plan created at `docs/testing/{feature-name}/{feature-name}.md`
+- [ ] Screenshots folder created
+- [ ] All scenarios manually verified
+- [ ] Screenshots taken and saved
+- [ ] Issues found have been fixed
+- [ ] E2E test file created in `e2e/`
+- [ ] All e2e tests pass locally
+- [ ] Data-testid attributes added to key elements
+
+## Test Credentials
+- Email: `admin@test.local`
+- Password: `TestAdmin123!`
+- Role: admin (local development only)


### PR DESCRIPTION
## Pull Request Type
feat

## Purpose
Add the `cf-saas-stack` plugin to the marketplace — a comprehensive set of skills, commands, and agents for building SaaS applications on Cloudflare Workers with React Router v7, tRPC, D1/Drizzle, and Better Auth.

This PR includes:
- **25 skills** covering auth, database, emails, Stripe, i18n, feature flags, testing, and more
- **11 slash commands** for architecture tracking, DB migrations, feature implementation, and PR validation
- **5 agents** for architecture tracking, context keeping, data analytics, logging, and testing
- **3 MCP servers** (Tavily, Playwright, PostHog) using `bunx` instead of `npx`
- Plugin registered in the marketplace manifest (`.claude-plugin/marketplace.json`)

## Breaking Changes
None

## Test Cases
- [ ] Run `/plugin install cf-saas-stack` and verify it installs successfully
- [ ] Verify all 11 commands are available via `/cf-saas-stack:*`
- [ ] Verify all 25 skills load correctly
- [ ] Confirm MCP servers use `bunx` (not `npx`) in plugin.json
- [ ] Confirm `cf-saas-stack` appears in marketplace.json plugins array

## Notes
- MCP server commands use `bunx` instead of `npx` for consistency with the project's bun toolchain
- The plugin is self-contained under `cf-saas-stack/` with its own `.claude-plugin/plugin.json`

## Self Checklist
- [x] Plugin registered in marketplace manifest
- [x] MCP servers use `bunx`
- [x] README updated with plugin listing
- [ ] Code reviewed against conventions