### PR TITLE
feat(casper): Add LinkedIn engagement scraper skill

### DIFF
--- a/casper/skills/linkedin-engagement-scraper/SKILL.md
+++ b/casper/skills/linkedin-engagement-scraper/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: linkedin-engagement-scraper
+description: >
+  Scrape LinkedIn post commenters and export Lemlist-ready CSVs, with optional ICP filtering.
+  Use this skill when the user wants to scrape engagement from a LinkedIn post, extract commenters,
+  build a lead list from LinkedIn post interactions, generate a CSV for Lemlist import, or filter
+  scraped contacts against an Ideal Customer Profile. Triggers on "scrape LinkedIn post",
+  "get commenters", "LinkedIn engagement", "post engagers", "Lemlist CSV", "who commented on this post",
+  "ICP filter", "ideal customer profile", or "filter leads".
+---
+
+# LinkedIn Engagement Scraper
+
+Scrape everyone who engaged with a LinkedIn post and produce two Lemlist-ready outputs:
+
+1. **All engagers** — everyone who commented, ready for Lemlist import
+2. **ICP matches** — only the people who match your Ideal Customer Profile
+
+## Pipeline
+
+```
+LinkedIn post URL
+        ↓
+scrape_engagers.py (PhantomBuster API)
+        ↓
+    ┌───┴───┐
+    │       │
+    ▼       ▼
+All CSV   engagers.json
+(Lemlist)     │
+              ▼
+        filter_icp.py (define ICP → score → filter)
+              │
+              ▼
+        ICP Matches CSV
+          (Lemlist)
+```
+
+## Prerequisites
+
+| Requirement | Details |
+|-------------|---------|
+| `PHANTOMBUSTER_API_KEY` | [Settings → API](https://phantombuster.com/settings#api) |
+| `PHANTOMBUSTER_AGENT_ID` | From phantom URL: `phantombuster.com/phantoms/<ID>/...` |
+| Python packages | `pip install requests python-dotenv` |
+
+Set the env vars in a `.env` file in the working directory.
+See `references/phantombuster-setup.md` for full PhantomBuster setup instructions.
+
+## Step 1: Scrape Engagers
+
+```bash
+python <skill-path>/scripts/scrape_engagers.py "<linkedin_post_url>"
+```
+
+This launches PhantomBuster, waits for results, and outputs:
+
+| File | Purpose |
+|------|---------|
+| `output/all_engagers_YYYY-MM-DD_HHMMSS.csv` | All contacts, Lemlist-ready. Import directly. |
+| `output/engagers.json` | Full contact data with seniority tagging. Feed to Step 2. |
+
+## Step 2: Filter by ICP (Optional)
+
+```bash
+python <skill-path>/scripts/filter_icp.py output/engagers.json
+```
+
+The script prompts you to define your ICP interactively:
+
+```
+--- Define your Ideal Customer Profile ---
+
+Segment 1:
+  Industries (comma-separated, or blank for any): saas, fintech
+  Target titles/keywords (comma-separated, or blank for any): vp, head of, director
+  Minimum seniority [c_suite / vp / director / manager / senior_ic / any]: director
+  Company name keywords (comma-separated, or blank for any):
+
+  Add another segment? (y/n): n
+```
+
+Or reuse a saved ICP:
+
+```bash
+python <skill-path>/scripts/filter_icp.py output/engagers.json --icp output/icp_criteria.json
+```
+
+Output:
+
+| File | Purpose |
+|------|---------|
+| `output/icp_matches_YYYY-MM-DD_HHMMSS.csv` | Strong + likely ICP matches, Lemlist-ready |
+| `output/icp_criteria.json` | Your saved ICP (reuse on future scrapes) |
+
+## ICP Matching Logic
+
+Each contact is scored against your ICP segments on four dimensions:
+
+| Dimension | Source | What it checks |
+|-----------|--------|----------------|
+| **Title keywords** | LinkedIn headline | Does their title contain your target keywords? |
+| **Company keywords** | LinkedIn headline | Does their company match your targets? |
+| **Seniority** | Parsed from title | Are they at or above your minimum seniority level? |
+| **Industry** | LinkedIn headline | Does their company/headline match your target industries? |
+
+Fit ratings:
+- **Strong fit** — Matches all active criteria
+- **Likely fit** — Matches all but one criterion
+- **Weak fit** — Partial match
+- **No fit** — Doesn't match
+
+The ICP CSV includes strong + likely fits. Weak fits are output as a fallback if no strong/likely matches exist.
+
+## Seniority Levels
+
+Parsed automatically from job titles:
+
+| Level | Example titles |
+|-------|---------------|
+| `c_suite` | CEO, CTO, Founder, Chief __ Officer |
+| `vp` | VP, SVP, Head of, Partner |
+| `director` | Director, Senior Director, Managing Director |
+| `manager` | Manager, Senior Manager, Product Manager |
+| `senior_ic` | Principal, Staff, Lead, Architect |
+| `individual_contributor` | Everything else |
+
+See `references/icp-parsing-guide.md` for detailed parsing rules.
+
+## Lemlist CSV Columns
+
+Both output CSVs use the same Lemlist-compatible format:
+
+| Column | Description |
+|--------|-------------|
+| `email` | Blank — Lemlist enriches from LinkedIn URL on import |
+| `firstName` | First name |
+| `lastName` | Last name |
+| `companyName` | Company (extracted from LinkedIn headline) |
+| `linkedinUrl` | LinkedIn profile URL |
+| `jobTitle` | Job title (extracted from LinkedIn headline) |
+| `icebreaker` | Comment text — use `{{icebreaker}}` in Lemlist templates |
+| `icpFit` | _(ICP CSV only)_ strong_fit or likely_fit |
+
+## Importing into Lemlist
+
+1. Open Lemlist → your campaign → Import
+2. Upload the CSV (either `all_engagers` or `icp_matches`)
+3. Lemlist auto-enriches emails from the LinkedIn URLs
+4. Use `{{icebreaker}}` in your email template for personalization
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| `412 Precondition Failed` on launch | Enable auto-launch in PhantomBuster phantom settings |
+| `403` or auth errors | Check `PHANTOMBUSTER_API_KEY` in `.env` |
+| 0 contacts returned | Post has no comments, or PhantomBuster session cookie expired |
+| Missing company/title | Person's headline doesn't follow "Title at Company" format |
+| 0 ICP matches | Broaden criteria — try fewer keywords or lower seniority minimum |

--- a/casper/skills/linkedin-engagement-scraper/references/icp-parsing-guide.md
+++ b/casper/skills/linkedin-engagement-scraper/references/icp-parsing-guide.md
@@ -1,0 +1,117 @@
+# ICP Parsing Guide
+
+How to turn natural language into structured ICP segments.
+
+## Core Concept: Segments
+
+An ICP is composed of one or more **segments**. Each segment defines a target pocket of the market.
+Users almost always think in segments even if they don't use that word — they'll say "I also want..."
+or "and then for healthcare..." which signals a new segment.
+
+## Parsing Rules
+
+### 1. Identify Segment Boundaries
+
+Listen for these signals that the user is defining a new segment:
+- Industry shift: "...and then for healthcare companies..."
+- Conjunction with new criteria: "Also interested in..."
+- Contrasting criteria: "But for smaller companies, I want..."
+
+If the user describes one set of criteria with no segment signals, treat it as a single segment.
+
+### 2. Extract Criteria Per Segment
+
+For each segment, extract whatever the user provides from these dimensions:
+
+| Dimension | Examples | Notes |
+|---|---|---|
+| **Industry** | Financial services, healthcare, SaaS, manufacturing | Map to standard industry categories |
+| **Company size** | Revenue range, AUM, employee count, funding stage | Capture the metric AND the range |
+| **Company tier** | Fortune 500/1000/2000, Inc 5000, public vs. private | These are separate from size |
+| **Geography** | US-based, EMEA, specific states/countries | Often implied (e.g., Fortune 2000 implies US-centric) |
+| **Target titles** | Head of AI, VP Engineering, CTO, Director of Data | See title normalization below |
+| **Seniority level** | C-suite, VP+, Director+, Manager+ | Sometimes given as a floor |
+| **Other qualifiers** | "Companies currently hiring for AI roles", "Recently raised Series B+" | Capture as free-text criteria |
+
+### 3. Handle Implied Criteria
+
+Users often leave things implicit. Common patterns:
+
+- **"Fortune 2000"** implies large US-centric companies, typically $1B+ revenue
+- **"Head of AI"** without seniority context implies VP-equivalent or above
+- **"AUM"** only applies to financial services — if the user mentions AUM for a non-financial segment, clarify
+- **"Startups"** typically means Series A–C, <500 employees, unless they specify otherwise
+
+When criteria are implied, include them in your confirmation but mark them as inferred:
+> "I'm assuming Fortune 2000 means US-centric companies — is that right?"
+
+### 4. Handle Ambiguity
+
+If the user says something genuinely ambiguous, ask. Common ambiguities:
+
+- **"Big companies"** — What's big? Revenue? Headcount? Give them options.
+- **"Tech leaders"** — Title (CTO, VP Eng) or companies that are tech leaders?
+- **"AI people"** — People who work in AI, or people at AI companies?
+
+Don't over-ask though. If you can reasonably infer intent, confirm your interpretation rather than
+asking an open-ended question.
+
+## Title Normalization
+
+Job titles on LinkedIn are messy. Here's how to map common titles to seniority levels:
+
+### C-Suite
+CEO, CTO, CIO, CDO (Chief Data Officer), CAIO (Chief AI Officer), CFO, COO, CMO,
+Chief [Anything] Officer, Co-Founder, Founder
+
+### VP Level
+VP, Vice President, SVP, Senior Vice President, EVP, Executive Vice President,
+Head of [Department], Global Head of [Department]
+
+### Director Level
+Director, Senior Director, Managing Director (context-dependent — in banking this is more senior),
+Group Director, Associate Director (borderline — include if user says "Director+")
+
+### Manager Level
+Manager, Senior Manager, Program Manager, Product Manager, Engineering Manager
+
+### Individual Contributor (Senior)
+Principal, Staff, Senior [Role], Lead [Role], Architect
+
+### Mapping Rules
+- "VP+" means VP Level and above (C-Suite + VP)
+- "Director+" means Director Level and above
+- Treat "Head of" as VP-equivalent regardless of whether it says VP
+- "Partner" at consulting/law/VC firms is C-Suite equivalent
+- "Managing Director" at banks/financial firms is senior (VP+ equivalent)
+- When in doubt, include the contact and note the ambiguity
+
+## Output Format
+
+After parsing, structure the ICP as:
+
+```json
+{
+  "segments": [
+    {
+      "name": "Financial Services",
+      "industry": ["financial services", "banking", "asset management", "insurance"],
+      "company_size": {
+        "metric": "aum",
+        "min": 1000000000,
+        "max": 10000000000
+      },
+      "company_tier": ["Fortune 2000"],
+      "target_titles": {
+        "keywords": ["AI", "ML", "machine learning", "data", "artificial intelligence"],
+        "min_seniority": "vp"
+      },
+      "geography": null,
+      "other_qualifiers": []
+    }
+  ]
+}
+```
+
+This structure is for your internal use during filtering — don't show the raw JSON to the user.
+Show them the human-readable confirmation table instead.

--- a/casper/skills/linkedin-engagement-scraper/references/phantombuster-setup.md
+++ b/casper/skills/linkedin-engagement-scraper/references/phantombuster-setup.md
@@ -1,0 +1,65 @@
+# PhantomBuster Setup
+
+One-time setup to configure the LinkedIn Post Commenters phantom.
+
+## Account & Pricing
+
+Sign up at [phantombuster.com](https://www.phantombuster.com). Starter plan ($69/mo) is sufficient.
+There's a 14-day free trial.
+
+## Create the Phantom
+
+1. Go to the [Phantom Store](https://phantombuster.com/phantoms)
+2. Search for **"LinkedIn Post Commenters Export"** (also called "LinkedIn Post Commenter and Liker Scraper")
+3. Click **"Use this Phantom"**
+
+## Connect LinkedIn
+
+The phantom needs your LinkedIn session cookie to browse LinkedIn on your behalf.
+
+**Option A — Browser extension (recommended):**
+1. Install the [PhantomBuster Chrome extension](https://chrome.google.com/webstore/detail/phantombuster/mdlnjfcpdiaclglfbdkbleiamdafilil)
+2. Log into LinkedIn in Chrome
+3. The extension auto-detects your `li_at` cookie
+
+**Option B — Manual:**
+1. Log into LinkedIn in Chrome
+2. Open DevTools (F12) → Application → Cookies → `linkedin.com`
+3. Find the `li_at` cookie and copy its value
+4. Paste it into the PhantomBuster phantom's session cookie field
+
+## Configure the Phantom
+
+- Put any placeholder LinkedIn post URL (the script overrides this at runtime)
+- Under "Engagers to extract", select **Commenters**
+- Save the phantom
+
+## Enable API Launch
+
+**This is required** — without it the script gets a 412 error.
+
+1. Open your phantom's settings
+2. Go to the launch/schedule section
+3. Enable **auto-launch** (either "Repeatedly" schedule or manual API launch)
+4. Save
+
+## Get Your Credentials
+
+| Credential | Where |
+|-----------|-------|
+| **API Key** | [Settings → API](https://phantombuster.com/settings#api) |
+| **Agent ID** | From the phantom URL: `phantombuster.com/phantoms/<AGENT_ID>/...` |
+
+## Session Cookie Expiry
+
+LinkedIn session cookies expire periodically (~30 days). If the scraper stops returning results,
+refresh the cookie in PhantomBuster using the same process above.
+
+## API Endpoints Used
+
+| Endpoint | Purpose |
+|----------|---------|
+| `POST /api/v2/agents/launch` | Launch the phantom with a post URL |
+| `GET /api/v2/agents/fetch-output` | Poll for completion status |
+| `GET /api/v2/agents/fetch` | Get S3 folder path for results |
+| S3 download | Download the JSON result file |

--- a/casper/skills/linkedin-engagement-scraper/references/research-playbook.md
+++ b/casper/skills/linkedin-engagement-scraper/references/research-playbook.md
@@ -1,0 +1,76 @@
+# Company Research Playbook
+
+How to efficiently research companies for ICP matching using web search.
+
+## Search Strategy
+
+### Batch by Company, Not by Contact
+
+If your contact list has 200 people across 80 companies, you need 80 searches — not 200.
+Deduplicate companies first, research each once, then apply the results to all contacts at
+that company.
+
+### Search Query Templates
+
+For each company, run targeted searches. Here are the queries that tend to yield the best results:
+
+**Revenue / Size:**
+- `"[Company Name]" revenue 2025` or `"[Company Name]" annual revenue`
+- `"[Company Name]" AUM` (for financial firms)
+- `"[Company Name]" employees OR headcount`
+
+**Industry Classification:**
+- `"[Company Name]" industry OR sector site:linkedin.com` (LinkedIn company pages are reliable)
+- `"[Company Name]" what does [company] do`
+
+**Tier / Rankings:**
+- `"[Company Name]" Fortune 500 OR Fortune 1000 OR Fortune 2000`
+- `"[Company Name]" Inc 5000 OR "fastest growing"`
+
+**AI Signals (optional, for enrichment):**
+- `"[Company Name]" artificial intelligence OR "AI initiative" OR "machine learning"`
+- `"[Company Name]" hiring AI OR "head of AI" site:linkedin.com`
+
+### Handling Edge Cases
+
+**Subsidiaries:** If someone works at "AWS" but the parent is Amazon, research Amazon for
+size/tier but note the subsidiary. The contact's relevance depends on whether they work in
+a division relevant to the ICP.
+
+**Name collisions:** "Mercury" could be a fintech, a car brand, or a NASA program. Use the
+person's title and LinkedIn context to disambiguate. If the CSV has a LinkedIn URL column, that's
+the fastest way to resolve.
+
+**Recently acquired companies:** If a company was acquired, note this. The contact might still
+list the old company name on LinkedIn. Research both the old company and the acquirer.
+
+**Private companies:** Revenue data is harder to find. Look for:
+- Funding announcements (Crunchbase-style: "raised $X Series Y" → infer rough valuation)
+- Employee count on LinkedIn (useful proxy for company size)
+- Industry reports or press coverage mentioning revenue ranges
+- Job postings volume (proxy for growth)
+
+If you truly can't find sizing data, classify as "insufficient data" and include the contact
+anyway with a note. The user may have direct knowledge.
+
+## Research Confidence Levels
+
+Tag each company with a confidence level:
+
+- **High** — Revenue/AUM from a reliable source (SEC filings, Fortune list, major publication).
+  Industry clearly categorized.
+- **Medium** — Revenue estimated from funding, headcount, or secondary sources. Industry is clear
+  but size is approximate.
+- **Low** — Minimal public data. Industry inferred from job titles or vague descriptions.
+  Size unknown.
+- **Unverified** — Couldn't find the company or results are ambiguous. Don't guess.
+
+## Efficiency Tips
+
+- Process the top 30-50 companies first (by how many contacts you have there), then ask the user
+  if they want you to continue with the long tail of companies that have only 1 contact each.
+- If the user gave a strict company tier requirement (e.g., "Fortune 2000 only"), you can
+  pre-filter: search the Fortune list first, drop companies not on it, and save yourself from
+  researching irrelevant companies.
+- Cache results mentally — if three people work at Goldman Sachs, don't search Goldman Sachs
+  three times.

--- a/casper/skills/linkedin-engagement-scraper/scripts/filter_icp.py
+++ b/casper/skills/linkedin-engagement-scraper/scripts/filter_icp.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""
+ICP Filter for LinkedIn Engagers
+Filters scraped engagers against an Ideal Customer Profile and outputs
+a Lemlist-ready CSV of matching contacts.
+
+Usage:
+    python filter_icp.py <engagers_json> [--icp <icp_json>]
+
+Interactive mode (no --icp flag):
+    Prompts you to define your ICP, then filters and outputs matches.
+
+Automated mode (with --icp flag):
+    Reads ICP criteria from a JSON file. Useful for rerunning the same
+    filter on new scrapes.
+
+Output:
+    output/icp_matches_YYYY-MM-DD_HHMMSS.csv  — Lemlist-ready CSV of ICP matches
+"""
+
+import csv
+import json
+import os
+import re
+import sys
+from datetime import datetime
+
+LEMLIST_COLUMNS = [
+    "email", "firstName", "lastName", "companyName",
+    "linkedinUrl", "jobTitle", "icebreaker", "icpFit",
+]
+
+SENIORITY_HIERARCHY = [
+    "c_suite", "vp", "director", "manager", "senior_ic", "individual_contributor", "unknown"
+]
+
+
+def load_engagers(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def load_icp(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def prompt_icp():
+    """Interactive ICP definition."""
+    print("\n--- Define your Ideal Customer Profile ---\n")
+
+    icp = {"segments": []}
+    segment_num = 1
+
+    while True:
+        print(f"Segment {segment_num}:")
+
+        industries = input("  Industries (comma-separated, or blank for any): ").strip()
+        titles = input("  Target titles/keywords (comma-separated, or blank for any): ").strip()
+        min_seniority = input("  Minimum seniority [c_suite / vp / director / manager / senior_ic / any]: ").strip()
+        company_keywords = input("  Company name keywords (comma-separated, or blank for any): ").strip()
+
+        segment = {}
+        if industries:
+            segment["industries"] = [i.strip().lower() for i in industries.split(",")]
+        if titles:
+            segment["title_keywords"] = [t.strip().lower() for t in titles.split(",")]
+        if min_seniority and min_seniority != "any":
+            segment["min_seniority"] = min_seniority.strip().lower()
+        if company_keywords:
+            segment["company_keywords"] = [c.strip().lower() for c in company_keywords.split(",")]
+
+        if segment:
+            segment["name"] = f"Segment {segment_num}"
+            icp["segments"].append(segment)
+            segment_num += 1
+
+        more = input("\n  Add another segment? (y/n): ").strip().lower()
+        if more != "y":
+            break
+
+    # Save ICP for reuse
+    os.makedirs("output", exist_ok=True)
+    icp_path = "output/icp_criteria.json"
+    with open(icp_path, "w") as f:
+        json.dump(icp, f, indent=2)
+    print(f"\nICP saved to {icp_path} (reuse with --icp flag)\n")
+
+    return icp
+
+
+def seniority_meets_minimum(contact_seniority, min_seniority):
+    """Check if the contact's seniority meets the minimum threshold."""
+    if not min_seniority:
+        return True
+    try:
+        contact_rank = SENIORITY_HIERARCHY.index(contact_seniority)
+        min_rank = SENIORITY_HIERARCHY.index(min_seniority)
+    except ValueError:
+        return True
+    return contact_rank <= min_rank
+
+
+def match_contact(contact, icp):
+    """Score a contact against all ICP segments. Returns (fit_level, matched_segment)."""
+    title_lower = (contact.get("jobTitle") or "").lower()
+    company_lower = (contact.get("companyName") or "").lower()
+    occupation_lower = (contact.get("occupationRaw") or "").lower()
+    seniority = contact.get("seniority", "unknown")
+
+    best_fit = "no_fit"
+    best_segment = None
+
+    for segment in icp.get("segments", []):
+        title_match = True
+        company_match = True
+        seniority_match = True
+        industry_match = True
+
+        # Title keywords
+        if segment.get("title_keywords"):
+            title_match = any(
+                kw in title_lower or kw in occupation_lower
+                for kw in segment["title_keywords"]
+            )
+
+        # Company keywords
+        if segment.get("company_keywords"):
+            company_match = any(
+                kw in company_lower or kw in occupation_lower
+                for kw in segment["company_keywords"]
+            )
+
+        # Seniority
+        if segment.get("min_seniority"):
+            seniority_match = seniority_meets_minimum(seniority, segment["min_seniority"])
+
+        # Industry (matched against occupation since we don't have a separate industry field)
+        if segment.get("industries"):
+            industry_match = any(
+                ind in occupation_lower or ind in company_lower
+                for ind in segment["industries"]
+            )
+
+        # Score
+        signals = [title_match, company_match, seniority_match, industry_match]
+        active_criteria = sum(1 for s in [
+            segment.get("title_keywords"),
+            segment.get("company_keywords"),
+            segment.get("min_seniority"),
+            segment.get("industries"),
+        ] if s)
+
+        if active_criteria == 0:
+            continue
+
+        passing = sum(signals[:active_criteria]) if active_criteria <= len(signals) else sum(signals)
+        # Recalculate: only count criteria that were actually set
+        checks = []
+        if segment.get("title_keywords"):
+            checks.append(title_match)
+        if segment.get("company_keywords"):
+            checks.append(company_match)
+        if segment.get("min_seniority"):
+            checks.append(seniority_match)
+        if segment.get("industries"):
+            checks.append(industry_match)
+
+        passing = sum(checks)
+        total = len(checks)
+
+        if total > 0 and passing == total:
+            fit = "strong_fit"
+        elif total > 0 and passing >= total - 1 and passing > 0:
+            fit = "likely_fit"
+        elif passing > 0:
+            fit = "weak_fit"
+        else:
+            fit = "no_fit"
+
+        fit_rank = ["strong_fit", "likely_fit", "weak_fit", "no_fit"]
+        if fit_rank.index(fit) < fit_rank.index(best_fit):
+            best_fit = fit
+            best_segment = segment.get("name", "")
+
+    return best_fit, best_segment
+
+
+def filter_contacts(contacts, icp):
+    """Filter and score all contacts against the ICP."""
+    results = {"strong_fit": [], "likely_fit": [], "weak_fit": [], "no_fit": []}
+
+    for contact in contacts:
+        fit, segment = match_contact(contact, icp)
+        contact_copy = dict(contact)
+        contact_copy["icpFit"] = fit
+        contact_copy["matchedSegment"] = segment or ""
+        results[fit].append(contact_copy)
+
+    return results
+
+
+def write_lemlist_csv(contacts, filename):
+    with open(filename, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=LEMLIST_COLUMNS, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(contacts)
+    print(f"Wrote {len(contacts)} contacts to {filename}")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python filter_icp.py <engagers_json> [--icp <icp_json>]")
+        sys.exit(1)
+
+    engagers_path = sys.argv[1]
+    contacts = load_engagers(engagers_path)
+    print(f"Loaded {len(contacts)} contacts from {engagers_path}")
+
+    # Load or prompt for ICP
+    icp = None
+    if "--icp" in sys.argv:
+        icp_idx = sys.argv.index("--icp")
+        if icp_idx + 1 < len(sys.argv):
+            icp = load_icp(sys.argv[icp_idx + 1])
+            print(f"Loaded ICP from {sys.argv[icp_idx + 1]}")
+
+    if not icp:
+        icp = prompt_icp()
+
+    # Print ICP summary
+    print("ICP Segments:")
+    for seg in icp.get("segments", []):
+        print(f"  {seg.get('name', 'Unnamed')}:")
+        if seg.get("industries"):
+            print(f"    Industries: {', '.join(seg['industries'])}")
+        if seg.get("title_keywords"):
+            print(f"    Title keywords: {', '.join(seg['title_keywords'])}")
+        if seg.get("min_seniority"):
+            print(f"    Min seniority: {seg['min_seniority']}")
+        if seg.get("company_keywords"):
+            print(f"    Company keywords: {', '.join(seg['company_keywords'])}")
+
+    # Filter
+    results = filter_contacts(contacts, icp)
+
+    strong = results["strong_fit"]
+    likely = results["likely_fit"]
+    weak = results["weak_fit"]
+    no_fit = results["no_fit"]
+
+    print(f"\nResults:")
+    print(f"  Strong fit: {len(strong)}")
+    print(f"  Likely fit: {len(likely)}")
+    print(f"  Weak fit:   {len(weak)}")
+    print(f"  No fit:     {len(no_fit)}")
+
+    # Output: ICP matches (strong + likely) as Lemlist CSV
+    icp_matches = strong + likely
+    os.makedirs("output", exist_ok=True)
+    ts = datetime.now().strftime("%Y-%m-%d_%H%M%S")
+
+    if icp_matches:
+        write_lemlist_csv(icp_matches, f"output/icp_matches_{ts}.csv")
+    else:
+        print("\nNo strong or likely matches found. Try broadening your ICP criteria.")
+        # Still write weak fits if any
+        if weak:
+            write_lemlist_csv(weak, f"output/icp_weak_matches_{ts}.csv")
+            print(f"Wrote {len(weak)} weak matches as fallback.")
+
+    print("\nDone!")
+
+
+if __name__ == "__main__":
+    main()

--- a/casper/skills/linkedin-engagement-scraper/scripts/scrape_engagers.py
+++ b/casper/skills/linkedin-engagement-scraper/scripts/scrape_engagers.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""
+LinkedIn Engagement Scraper
+Scrapes commenters from a LinkedIn post via PhantomBuster,
+parses their profiles, and outputs a Lemlist-ready CSV.
+
+Usage:
+    python scrape_engagers.py <linkedin_post_url>
+
+Output:
+    output/all_engagers_YYYY-MM-DD_HHMMSS.csv   — All scraped contacts
+    output/engagers.json                         — Raw JSON for ICP filtering
+"""
+
+import csv
+import json
+import os
+import re
+import sys
+import time
+from datetime import datetime
+from functools import partial
+
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+print = partial(print, flush=True)
+
+# --- Config ---
+PB_API_KEY = os.getenv("PHANTOMBUSTER_API_KEY")
+PB_AGENT_ID = os.getenv("PHANTOMBUSTER_AGENT_ID")
+PB_BASE = "https://api.phantombuster.com/api/v2"
+
+LEMLIST_COLUMNS = ["email", "firstName", "lastName", "companyName", "linkedinUrl", "jobTitle", "icebreaker"]
+
+COMPANY_SUFFIXES = re.compile(
+    r",?\s*\b(Inc\.?|LLC\.?|Ltd\.?|Corp\.?|Corporation|Incorporated|Limited|"
+    r"PLC|plc|Co\.?|Company|Group|Holdings?|GmbH|AG|LLP|LP)\s*$",
+    re.IGNORECASE,
+)
+
+SENIORITY_PATTERNS = {
+    "c_suite": re.compile(
+        r"\b(CEO|CTO|CIO|CDO|CAIO|CFO|COO|CMO|CPO|CRO|CISO|"
+        r"Chief\s+\w+\s+Officer|Co-?Founder|Founder|President)\b",
+        re.IGNORECASE,
+    ),
+    "vp": re.compile(
+        r"\b(VP|Vice\s+President|SVP|Senior\s+Vice\s+President|"
+        r"EVP|Executive\s+Vice\s+President|Head\s+of|Global\s+Head|Partner)\b",
+        re.IGNORECASE,
+    ),
+    "director": re.compile(
+        r"\b(Director|Senior\s+Director|Managing\s+Director|"
+        r"Group\s+Director|Associate\s+Director)\b",
+        re.IGNORECASE,
+    ),
+    "manager": re.compile(
+        r"\b(Manager|Senior\s+Manager|Program\s+Manager|"
+        r"Product\s+Manager|Engineering\s+Manager)\b",
+        re.IGNORECASE,
+    ),
+    "senior_ic": re.compile(
+        r"\b(Principal|Staff|Senior\s+\w+|Lead\s+\w+|Architect)\b",
+        re.IGNORECASE,
+    ),
+}
+
+
+# --- PhantomBuster ---
+
+def launch_phantom(post_url):
+    print(f"Launching PhantomBuster for: {post_url}")
+    resp = requests.post(
+        f"{PB_BASE}/agents/launch",
+        headers={"X-Phantombuster-Key": PB_API_KEY},
+        json={"id": PB_AGENT_ID, "bonusArgument": {"postUrl": post_url}},
+    )
+    if not resp.ok:
+        print(f"PhantomBuster launch error ({resp.status_code}): {resp.text}")
+        sys.exit(1)
+    print(f"Phantom launched (container {resp.json().get('containerId')})")
+
+
+def wait_for_phantom():
+    print("Waiting for PhantomBuster to finish...")
+    while True:
+        resp = requests.get(
+            f"{PB_BASE}/agents/fetch-output",
+            headers={"X-Phantombuster-Key": PB_API_KEY},
+            params={"id": PB_AGENT_ID},
+        )
+        resp.raise_for_status()
+        status = resp.json().get("status")
+
+        if status == "finished":
+            print("  Done!")
+            break
+        if status == "error":
+            print(f"PhantomBuster error: {resp.json().get('output', 'unknown')}")
+            sys.exit(1)
+
+        print(f"  Still running... ({status})")
+        time.sleep(15)
+
+
+def download_results():
+    agent = requests.get(
+        f"{PB_BASE}/agents/fetch",
+        headers={"X-Phantombuster-Key": PB_API_KEY},
+        params={"id": PB_AGENT_ID},
+    ).json()
+
+    url = f"https://phantombuster.s3.amazonaws.com/{agent['orgS3Folder']}/{agent['s3Folder']}/result.json"
+    print("Downloading results...")
+    resp = requests.get(url)
+    resp.raise_for_status()
+
+    try:
+        return resp.json()
+    except json.JSONDecodeError:
+        return [json.loads(line) for line in resp.text.strip().split("\n") if line.strip()]
+
+
+# --- Data parsing ---
+
+def parse_occupation(occupation):
+    """Extract (job_title, company) from a LinkedIn occupation string."""
+    if not occupation:
+        return "", ""
+
+    for sep in (" at ", " @ "):
+        if sep in occupation:
+            title, rest = occupation.split(sep, 1)
+            company = COMPANY_SUFFIXES.sub("", rest.split("|")[0].strip()).strip()
+            return title.strip(), company
+
+    if ", " in occupation:
+        first, rest = occupation.split(", ", 1)
+        if len(first.split()) <= 5:
+            company = COMPANY_SUFFIXES.sub("", rest.split("|")[0].strip()).strip()
+            return first.strip(), company
+
+    return occupation, ""
+
+
+def extract_seniority(title):
+    """Return the highest seniority level found in the title."""
+    if not title:
+        return "unknown"
+    for level, pattern in SENIORITY_PATTERNS.items():
+        if pattern.search(title):
+            return level
+    return "individual_contributor"
+
+
+def build_contacts(raw):
+    """Convert PhantomBuster results into structured contact dicts."""
+    contacts = []
+    seen = set()
+
+    for person in raw:
+        url = person.get("profileUrl") or person.get("profileLink") or ""
+        if url in seen:
+            continue
+        if url:
+            seen.add(url)
+
+        first = person.get("firstName") or ""
+        last = person.get("lastName") or ""
+        if not first and person.get("fullName"):
+            parts = person["fullName"].split(" ", 1)
+            first = parts[0]
+            last = parts[1] if len(parts) > 1 else ""
+
+        occupation = person.get("occupation") or ""
+        title, company = parse_occupation(occupation)
+        comment = person.get("comments") or person.get("comment") or ""
+
+        contacts.append({
+            "email": "",
+            "firstName": first,
+            "lastName": last,
+            "companyName": company,
+            "linkedinUrl": url,
+            "jobTitle": title,
+            "icebreaker": comment,
+            # Extra fields for ICP filtering (not in Lemlist CSV)
+            "seniority": extract_seniority(title),
+            "occupationRaw": occupation,
+        })
+
+    return contacts
+
+
+# --- Output ---
+
+def write_lemlist_csv(contacts, filename):
+    """Write contacts to a Lemlist-formatted CSV (only Lemlist columns)."""
+    with open(filename, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=LEMLIST_COLUMNS, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(contacts)
+    print(f"Wrote {len(contacts)} contacts to {filename}")
+    return filename
+
+
+def write_json(contacts, filename):
+    """Write full contact data as JSON for ICP filtering."""
+    with open(filename, "w", encoding="utf-8") as f:
+        json.dump(contacts, f, indent=2, ensure_ascii=False)
+    print(f"Wrote {len(contacts)} contacts to {filename}")
+
+
+# --- Main ---
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python scrape_engagers.py <linkedin_post_url>")
+        sys.exit(1)
+
+    for var in ("PHANTOMBUSTER_API_KEY", "PHANTOMBUSTER_AGENT_ID"):
+        if not os.getenv(var):
+            print(f"Missing env var: {var}")
+            sys.exit(1)
+
+    post_url = sys.argv[1]
+    ts = datetime.now().strftime("%Y-%m-%d_%H%M%S")
+    os.makedirs("output", exist_ok=True)
+
+    # Stage 1: Scrape
+    launch_phantom(post_url)
+    wait_for_phantom()
+    raw = download_results()
+    print(f"Scraped {len(raw)} engagers.")
+
+    # Stage 2: Parse
+    contacts = build_contacts(raw)
+    print(f"{len(contacts)} unique contacts.")
+
+    # Stage 3: Output
+    # CSV with all engagers (Lemlist-ready)
+    write_lemlist_csv(contacts, f"output/all_engagers_{ts}.csv")
+    # JSON with full data (for ICP filtering)
+    write_json(contacts, "output/engagers.json")
+
+    print("\nDone! Two files ready:")
+    print(f"  1. output/all_engagers_{ts}.csv  — Import directly into Lemlist")
+    print(f"  2. output/engagers.json          — Feed to filter_icp.py for ICP matching")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds a new `linkedin-engagement-scraper` skill to the casper plugin
- Scrapes LinkedIn post commenters via PhantomBuster API and outputs Lemlist-ready CSVs
- Includes optional ICP (Ideal Customer Profile) filtering to narrow results by title, seniority, industry, and company

## What's included

| File | Purpose |
|------|---------|
| `SKILL.md` | Skill definition with full usage docs and troubleshooting |
| `scripts/scrape_engagers.py` | Post URL → PhantomBuster → `all_engagers.csv` + `engagers.json` |
| `scripts/filter_icp.py` | `engagers.json` → ICP criteria → `icp_matches.csv` |
| `references/phantombuster-setup.md` | One-time PhantomBuster setup guide |
| `references/icp-parsing-guide.md` | ICP parsing rules and title normalization |
| `references/research-playbook.md` | Company research patterns for enrichment |

## Two outputs (both Lemlist-ready)

1. **All engagers CSV** — everyone who commented on the post
2. **ICP matches CSV** — only contacts matching your ideal customer profile

## Prerequisites

- PhantomBuster account with "LinkedIn Post Commenters Export" phantom configured
- `PHANTOMBUSTER_API_KEY` and `PHANTOMBUSTER_AGENT_ID` env vars
- `pip install requests python-dotenv`

## Test plan

- [ ] Verify skill structure matches marketplace conventions (SKILL.md, scripts/, references/)
- [ ] Confirm no sensitive info (API keys, session cookies, client data)
- [ ] Test `scrape_engagers.py` with a real LinkedIn post URL
- [ ] Test `filter_icp.py` with generated `engagers.json`
- [ ] Verify both output CSVs import cleanly into Lemlist