### PR TITLE
chore: sync public marketplace to private mirror

### DIFF
--- a/.github/workflows/sync-private.yml
+++ b/.github/workflows/sync-private.yml
@@ -1,0 +1,32 @@
+name: Sync private marketplace
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+
+jobs:
+  sync:
+    if: github.repository == 'Casper-Studios/casper-marketplace'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone public marketplace
+        run: |
+          git clone --bare \
+            https://github.com/Casper-Studios/casper-marketplace.git \
+            upstream
+
+      - name: Sync branches and tags
+        env:
+          SYNC_TOKEN: ${{ secrets.PRIVATE_MARKETPLACE_TOKEN }}
+        run: |
+          cd upstream
+
+          git push --force --prune \
+            "https://x-access-token:${SYNC_TOKEN}@github.com/Casper-Studios/private-casper-marketplace.git" \
+            "refs/heads/*:refs/heads/*" \
+            "refs/tags/*:refs/tags/*"


### PR DESCRIPTION
## Pull Request Type

- chore

## Summary

- Add automated mirroring from the public `Casper-Studios/casper-marketplace` repository to `Casper-Studios/private-casper-marketplace`.
- Sync immediately after changes land on `main`, every six hours as a fallback, or through manual dispatch.
- Push only branches and tags, avoiding GitHub's protected `refs/pull/*` refs that caused the previous `git push --mirror` failure.

## Scope

- `.github/workflows/sync-private.yml`: adds the public-to-private marketplace sync workflow.
- GitHub repository configuration: requires the `PRIVATE_MARKETPLACE_TOKEN` Actions secret in the public repository.

## Key Changes

- Clones the public repository as a bare repository.
- Uses explicit `refs/heads/*` and `refs/tags/*` refspecs instead of `--mirror`.
- Uses `--force --prune` so private branches and tags match the public source.
- Restricts execution to `Casper-Studios/casper-marketplace` using a repository-name condition.
- Authenticates to the private repository with a fine-grained PAT limited to the target repository.

## Reviewer Guide

1. Review `.github/workflows/sync-private.yml` triggers and repository guard.
2. Confirm the branch/tag refspecs exclude `refs/pull/*`.
3. Confirm `PRIVATE_MARKETPLACE_TOKEN` exists and has only required permissions.
4. Confirm private-repository rules permit the token owner to force-push.

## Risk / Impact

- Runtime impact: one GitHub Actions job after each push to public `main`, plus a six-hour fallback schedule.
- Data/migration impact: none.
- Operational impact: `--force --prune` deletes private-only branches or tags and rewrites divergent refs. The private repository should be treated as a read-only mirror.
- Security impact: the PAT requires `Contents: read/write` and `Workflows: read/write` only for `private-casper-marketplace`.

## Validation

- [ ] Run the workflow manually with `workflow_dispatch` and confirm success.
- [ ] Confirm public and private `main` commit SHAs match after synchronization.
- [ ] Confirm branches and tags synchronize without `refs/pull/*` rejection errors.
- [ ] Push or merge a test change to public `main` and confirm immediate synchronization.

## Breaking Changes

- None for marketplace consumers.
- Private-only branches and tags are unsupported and may be removed during synchronization.

## Tickets

- None.

## Notes

- Configure `PRIVATE_MARKETPLACE_TOKEN` only in the public repository.
- The workflow file is copied into the private mirror, but its repository condition prevents execution there.
- Fine-grained PAT permissions: `Contents: read/write` and `Workflows: read/write` for `private-casper-marketplace`.

## Attachments

- Public source: https://github.com/Casper-Studios/casper-marketplace
- Private mirror: https://github.com/Casper-Studios/private-casper-marketplace