### PR TITLE
docs: document plugin version-bump convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Plugins are organized by workstream under `plugins/`.
 | engineering | [code-review](./plugins/engineering/code-review/) | Codebase audits for AI-agent readiness and code review |
 | engineering | [skill-authoring](./plugins/engineering/skill-authoring/) | Tooling for creating and updating Claude Code skills |
 | engineering | [marketplace-setup](./plugins/engineering/marketplace-setup/) | Security hooks, safe .env loading, and privacy settings |
-| engineering | [git-pr](./plugins/engineering/git-pr/) | Planning, commits, PR management, code polishing, session handoffs |
+| engineering | [git-pr](./plugins/engineering/git-pr/) | Committing, PR creation and review triage, dependency upgrades, and Linear ticket extraction |
 | engineering | [testing](./plugins/engineering/testing/) | Browser automation and testing |
 | engineering | [integrations](./plugins/engineering/integrations/) | Google Workspace and universal third-party app integrations |
 | engineering | [cf-saas-stack](./plugins/engineering/cf-saas-stack/) | Cloudflare SaaS stack patterns - auth, database, workflows, emails, Stripe, and more |
@@ -109,6 +109,8 @@ To add a new plugin:
 2. Add the required `.claude-plugin/plugin.json` manifest
 3. Add commands, scripts, and documentation
 4. Submit a PR
+
+When changing an existing plugin, bump its `.claude-plugin/plugin.json` `version` (and the matching `marketplace.json` entry) following semver — MAJOR for breaking changes like renaming a skill, MINOR for new features, PATCH for fixes. Without a bump, users won't receive the update.
 
 ## License
 

--- a/plugins/AGENTS.md
+++ b/plugins/AGENTS.md
@@ -14,3 +14,9 @@ After creating/editing any prompts, review the `git diff` to ensure no regressio
 - Skill names should be as specific as possible (e.g `generate-client-proposal` is better than `generate-doc`) 
 - Use hyphens instead of underscores in skill names and file paths 
 - Set `user-invocable: false` for internal skills. Skills that are only called by other skills, not directly by the user, should be marked as internal so they don't pollute the user-facing skill list.
+
+## Versioning
+
+- Bump the plugin's `.claude-plugin/plugin.json` `version` on every change users should receive — pushing commits alone ships nothing, since Claude Code caches by version.
+- Follow semver: MAJOR for breaking changes (renaming/removing a skill invocation), MINOR for new skills/features, PATCH for fixes.
+- Keep the plugin's `marketplace.json` entry in sync (`plugin.json` wins if they differ).


### PR DESCRIPTION
## Pull Request Type

- docs

## Summary

- Document the plugin version-bump convention so contributors don't ship silent no-op updates.
- Codify semver expectations (MAJOR/MINOR/PATCH) and the `plugin.json` ↔ `marketplace.json` sync rule for agents and humans alike.
- Refresh the stale `git-pr` description in the README plugin table.

## Scope

- `plugins/AGENTS.md`: new `## Versioning` section (agent-facing convention doc).
- `README.md`: version-bump note in the Contributing section + updated `git-pr` row description.

## Key Changes

- **Versioning guidance** captures the three gotchas we hit: (1) Claude Code caches by version so a bump is required for users to receive changes, (2) semver level matters — renaming/removing a skill invocation is a breaking (MAJOR) change, (3) `plugin.json` wins over the `marketplace.json` entry, so keep them in sync.
- Split by audience: full operational detail in `AGENTS.md`; a one-line pointer in the README Contributing section.
- README `git-pr` description no longer references removed skills (planning, code polishing, session handoffs).

## Reviewer Guide

1. `plugins/AGENTS.md` — the new Versioning section.
2. `README.md` — Contributing note + `git-pr` table row.

## Risk / Impact

- Runtime impact: None — documentation only.
- Data/migration impact: None.
- Operational impact: None.

## Validation

- [ ] N/A — documentation-only change, no automated checks apply.

## Breaking Changes

- None

## Tickets

- N/A

## Notes

- Guidance derived from the Claude Code [plugins reference — Version management](https://code.claude.com/docs/en/plugins-reference#version-management).

## Attachments

- None

## Self Checklist

- [ ] I have added/updated tests where needed
- [ ] I ran relevant local checks and documented results above
- [ ] Documentation was updated if behavior or workflow changed
- [ ] The database migration **DOES NOT _delete any data_** (if applicable)
