### PR TITLE
feat(gov): add marketplace governance plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
 	"name": "casper-studios",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"description": "A collection of Claude Code plugins for business automation, data analysis, and productivity",
 	"owner": {
 		"name": "Casper Studios",
@@ -70,6 +70,11 @@
 		{
 			"name": "stack-patterns",
 			"source": "./plugins/engineering/stack-patterns",
+			"strict": true
+		},
+		{
+			"name": "marketplace",
+			"source": "./plugins/governance/marketplace",
 			"strict": true
 		},
 		{

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Plugins are organized by workstream under `plugins/`.
 | engineering | [integrations](./plugins/engineering/integrations/) | Google Workspace and universal third-party app integrations |
 | engineering | [cf-saas-stack](./plugins/engineering/cf-saas-stack/) | Cloudflare SaaS stack patterns - auth, database, workflows, emails, Stripe, and more |
 | engineering | [stack-patterns](./plugins/engineering/stack-patterns/) | Idiomatic usage patterns for React, TanStack Table, and better-all |
+| governance | [marketplace](./plugins/governance/marketplace/) | Agent skill and plugin governance for focused marketplace packages |
 | product | [data-analysis](./plugins/product/data-analysis/) | Data analysis and storytelling for financial and RevOps contexts |
 | product | [csv-analyzer](./plugins/product/csv-analyzer/) | CSV data analysis, profiling, and visualization |
 | product | [discovery](./plugins/product/discovery/) | AI voice agent creation for client discovery and feedback calls |

--- a/plugins/governance/marketplace/.claude-plugin/plugin.json
+++ b/plugins/governance/marketplace/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+	"name": "marketplace",
+	"version": "0.1.0",
+	"description": "Agent skill and plugin governance guidance for focused, distributable marketplace packages.",
+	"author": { "name": "Casper Studios" }
+}

--- a/plugins/governance/marketplace/skills/agent-skills-best-practices/LICENSE.txt
+++ b/plugins/governance/marketplace/skills/agent-skills-best-practices/LICENSE.txt
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/plugins/governance/marketplace/skills/agent-skills-best-practices/SKILL.md
+++ b/plugins/governance/marketplace/skills/agent-skills-best-practices/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: agent-skills-best-practices
+description: Opinionated conventions for authoring, restructuring, and reviewing agent skills. Use when deciding whether guidance belongs in `SKILL.md`, a conditional reference, or a smaller skill; writing trigger descriptions and reference routers; naming procedural or documentary skills; creating examples; keeping skill context focused; or bundling static assets and their licenses.
+license: MPL-2.0
+metadata:
+  author: 'Basti Ortiz <ortiz@bastidood.dev>'
+  source: 'https://github.com/BastiDood/skills'
+---
+
+# Agent Skills Best Practices
+
+Treat agent skills as opinionated context engineering, not as mirrors of documentation that an agent can fetch elsewhere. A skill earns its context cost by preserving distinctive judgment, repeatable procedure, or peripheral knowledge that materially changes how an agent works.
+
+Keep the governing model and the minimum explainer needed to understand a skill in `SKILL.md`. Inline content that every invocation needs. Reserve progressive disclosure for conditional or detail-oriented guidance, and route to that guidance with concise prose that explains why it matters.
+
+## References
+
+Read as many linked references as are relevant to the authoring or review task.
+
+- When a capability must read clearly in discovery and invocation surfaces, choose a [procedural or documentary name](./references/skill-naming.md) that communicates what the skill provides.
+- When one skill begins collecting unrelated triggers or decisions, restore a [cohesive skill scope](./references/skill-scope.md) instead of growing an umbrella package.
+- When discovery is too broad, too narrow, or vague, make the [trigger description](./references/trigger-descriptions.md) name the capability and concrete situations that need it.
+- When deciding what enters the always-loaded entry point, use [context and disclosure](./references/context-and-disclosure.md) to separate the governing model from conditional detail.
+- When an index must make conditional material discoverable, write [reference routing](./references/reference-routing.md) that primes the agent with the relevant situation and decision.
+- When examples can expose or obscure the actual opinion, follow the [example conventions](./references/examples.md) instead of turning the skill into a tutorial.
+- When prose or Markdown formatting can distract from the rule, keep [skill writing](./references/prose-and-formatting.md) direct, compact, and mechanically consistent.
+- When resources begin forming subtrees, restore a [flat directory structure](./references/directory-structure.md) so every conditional resource stays one hop from its entry point.
+- When a skill governs one external library, keep [library source identifiers](./references/library-sources.md) visible without copying documentation into the skill.
+- When a skill would bundle images, fonts, documents, templates, or other blobs, apply the [asset distribution](./references/asset-distribution.md) policy before including them.

--- a/plugins/governance/marketplace/skills/agent-skills-best-practices/agents/openai.yaml
+++ b/plugins/governance/marketplace/skills/agent-skills-best-practices/agents/openai.yaml
@@ -1,0 +1,2 @@
+interface:
+  display_name: 'Agent Skills Best Practices'

--- a/plugins/governance/marketplace/skills/agent-skills-best-practices/references/asset-distribution.md
+++ b/plugins/governance/marketplace/skills/agent-skills-best-practices/references/asset-distribution.md
@@ -1,0 +1,9 @@
+# Asset Distribution
+
+Prefer not to distribute static assets. Fonts, images, PDFs, documents, templates, and other blobs introduce provenance, license, attribution, and redistribution obligations that prompt-only skills avoid.
+
+When an asset is essential, identify its source and license before adding it. Bundle every license and attribution file required by that asset's terms. A repository license does not replace a third-party asset's license.
+
+Do not redistribute a logo merely because the source repository contains it. A symlink, copied file, or package reference does not grant redistribution rights.
+
+Before release, inventory the packaged skill rather than only the source tree. Remove non-redistributable assets, remove their metadata references, and delete empty asset directories.

--- a/plugins/governance/marketplace/skills/agent-skills-best-practices/references/context-and-disclosure.md
+++ b/plugins/governance/marketplace/skills/agent-skills-best-practices/references/context-and-disclosure.md
@@ -1,0 +1,31 @@
+# Context and Disclosure
+
+Use `SKILL.md` for the minimum context that every invocation needs to understand and apply the skill. Start with a concise orientation that states the governing model and intended outcome.
+
+Inline a rule when the agent must load it on every invocation anyway. A reference creates no progressive disclosure when the entry point always requires the agent to read it.
+
+Move content behind a reference only when it is conditional, detail-oriented, or specific to one branch of the task. Do not require every reference by default. Load as much as the current task needs.
+
+<progressive_disclosure_examples>
+
+```markdown
+<!-- BAD: the entry point is only a table of contents. -->
+
+# API Best Practices
+
+## References
+
+- [Errors](./references/errors.md)
+- [Pagination](./references/pagination.md)
+```
+
+```markdown
+<!-- GOOD: the entry point explains the governing opinion first. -->
+
+# API Best Practices
+
+- Design APIs around stable domain contracts rather than transport convenience.
+- Keep caller policy visible and preserve information across boundaries.
+```
+
+</progressive_disclosure_examples>

--- a/plugins/governance/marketplace/skills/agent-skills-best-practices/references/directory-structure.md
+++ b/plugins/governance/marketplace/skills/agent-skills-best-practices/references/directory-structure.md
@@ -1,0 +1,26 @@
+# Directory Structure
+
+Keep skill packages as flat as the resource ownership permits. A skill entry point must be able to name each conditional resource directly without navigating a documentation tree.
+
+```text
+# BAD: taxonomy adds navigation without adding ownership.
+agent-skill/
+├── references/
+│   └── sections/
+│       └── routing/
+│           └── narrative-links.md
+└── assets/
+    └── fonts/
+        └── brand.woff2
+
+# GOOD: resources stay directly discoverable.
+agent-skill/
+├── references/
+│   └── narrative-links.md
+└── fonts/
+    └── brand.woff2
+```
+
+Use a deeper directory only when it is a real owned artifact, such as a complete template copied as one unit. Do not reproduce a document outline in the filesystem.
+
+Prefer another small skill over a deep reference hierarchy when a subtree has an independent trigger and reusable purpose.

--- a/plugins/governance/marketplace/skills/agent-skills-best-practices/references/examples.md
+++ b/plugins/governance/marketplace/skills/agent-skills-best-practices/references/examples.md
@@ -1,0 +1,39 @@
+# Examples
+
+Use examples to demonstrate an opinion that prose alone can leave ambiguous. Do not teach ordinary API syntax or reproduce a tutorial that current documentation can supply.
+
+Add a "BAD"/"GOOD" counterpart when the rejected approach is plausible, compiles, or appears to work. Keep a single example when the reference only establishes one canonical syntax or declarative shape.
+
+Put the labels inside the code fence as comments. The BAD implementation must remain real code; never comment it out. Use the same small scenario for both sides and change only the decision under review.
+
+```tsx
+// BAD: the state change hides a click-driven operation behind reactivity.
+import { useEffect, useState } from 'react';
+
+function save() {}
+
+function SaveButton() {
+	const [requested, setRequested] = useState(false);
+
+	useEffect(() => {
+		if (requested) save();
+	}, [requested]);
+
+	return <button onClick={() => setRequested(true)}>Save</button>;
+}
+```
+
+```tsx
+// GOOD: the event handler owns work caused by the event.
+function save() {}
+
+function SaveButton() {
+	return <button onClick={save}>Save</button>;
+}
+```
+
+Make every snippet self-contained and valid for its claimed language or framework. Do not leave undefined placeholders, invalid imports, conflicting declarations, or deprecated APIs in "GOOD" examples.
+
+Use a fence language that matches the snippet. A `json` fence cannot contain comments; use `jsonc` when comments are part of the example, or keep the explanation outside the fence.
+
+Do not use secondary Markdown headings for "GOOD" and "BAD". Do not preserve a bad example merely to achieve visual symmetry.

--- a/plugins/governance/marketplace/skills/agent-skills-best-practices/references/library-sources.md
+++ b/plugins/governance/marketplace/skills/agent-skills-best-practices/references/library-sources.md
@@ -1,0 +1,17 @@
+# Library Sources
+
+A skill dedicated to one external library keeps its lookup identifiers in `SKILL.md`, where they remain visible whenever the skill is active:
+
+```markdown
+## Library Sources
+
+- GitHub: `owner/repository`
+- Context7: `/owner/repository`
+- DeepWiki: `owner/repository`
+```
+
+Do not move these identifiers into some `documentation.md` reference. Lookup procedure is part of operating the skill, not conditional domain guidance.
+
+Use Context7 for current library documentation and DeepWiki when documentation is insufficient or conflicts with implementation. Verify identifiers before publishing them; never invent a missing ID.
+
+The skill must still encode conventions rather than copied documentation. Source identifiers make current documentation fetchable and remove the excuse for embedding a tutorial in the skill.

--- a/plugins/governance/marketplace/skills/agent-skills-best-practices/references/prose-and-formatting.md
+++ b/plugins/governance/marketplace/skills/agent-skills-best-practices/references/prose-and-formatting.md
@@ -1,0 +1,14 @@
+# Prose and Formatting
+
+Write direct, opinionated prose in the imperative style. State the decision and its consequence.
+
+- Do not pad a convention with a summary of documentation.
+- Do not hedge before doing the research needed to settle the claim.
+
+Keep orientation prose short enough to prime the agent without becoming a second reference. Keep routers to one sentence. Do not reduce them to bland `use XYZ` commands, and do not expand them into full explanatory paragraphs.
+
+Use title case for headings. Let the renderer wrap prose instead of inserting manual line breaks.
+
+Use ordinary ASCII quotes and apostrophes in Markdown. En dashes, em dashes, and directory-tree glyphs are acceptable when they improve readability.
+
+When code comments label examples, use `GOOD:` and `BAD:`. Do not use dash or em-dash variants for these labels.

--- a/plugins/governance/marketplace/skills/agent-skills-best-practices/references/reference-routing.md
+++ b/plugins/governance/marketplace/skills/agent-skills-best-practices/references/reference-routing.md
@@ -1,0 +1,35 @@
+# Reference Routing
+
+Put the reference-consumption instruction directly under a `References` subheading.
+
+Index every reference exactly once from `SKILL.md`. Use an explicit `./` relative path. Keep references one hop from the entry point, and do not link from one reference to another.
+
+Write each router as one concise sentence that hooks/establishes the triggering situation and governing opinion or failure mode. Hyperlink the phrase that names the relevant decision.
+
+```markdown
+<!-- BAD: a filename with no narrative relevance. -->
+
+- [Validation](./references/validation.md)
+```
+
+```markdown
+<!-- BAD: an artificial command that still does not explain the decision. -->
+
+- For validation, use [validation](./references/validation.md).
+```
+
+```markdown
+<!-- BAD: a miniature reference defeats selective loading. -->
+
+- When validation is needed, read [validation](./references/validation.md), which
+  covers link checking, formatting, schemas, examples, forward tests, and more.
+```
+
+```markdown
+<!-- GOOD: the situation and expected protection make the link relevant. -->
+
+- When examples can drift from their claimed API, apply the
+  [semantic validation gate](./references/validation.md) before release.
+```
+
+Do not make a router a topic label. Do not make it a paragraph. The linked reference owns the details.

--- a/plugins/governance/marketplace/skills/agent-skills-best-practices/references/skill-naming.md
+++ b/plugins/governance/marketplace/skills/agent-skills-best-practices/references/skill-naming.md
@@ -1,0 +1,25 @@
+# Skill Naming
+
+Name a skill after the capability it gives the agent. The name must reveal whether the skill performs a procedure or supplies documentary guidance.
+
+Use a verb-noun pair for an entirely procedural workflow:
+
+```yaml
+# BAD: the name does not say what action the workflow performs.
+name: pull-request
+
+# GOOD: the workflow writes a pull request.
+name: write-pull-request
+```
+
+Use a descriptive adjective-noun pair for peripheral knowledge or conventions:
+
+```yaml
+# BAD: an imperative name misrepresents documentary guidance as a workflow.
+name: optimize-nextjs
+
+# GOOD: the skill supplies an opinionated body of guidance.
+name: nextjs-best-practices
+```
+
+Do not name a skill after its implementation mechanism, resource type, or internal stage unless that mechanism is the capability users actually seek.

--- a/plugins/governance/marketplace/skills/agent-skills-best-practices/references/skill-scope.md
+++ b/plugins/governance/marketplace/skills/agent-skills-best-practices/references/skill-scope.md
@@ -1,0 +1,7 @@
+# Skill Scope
+
+Keep one skill responsible for one coherent procedure or body of knowledge. Split it when a part has its own trigger, can be reused independently, or can evolve without the rest.
+
+Do not split a skill merely to make its files shorter. Two documents that always trigger together and cannot be reused separately are one context boundary.
+
+Do not expand a skill because adjacent guidance seems useful. A skill that owns several unrelated decisions will trigger too broadly, spend context unnecessarily, and become difficult to revise without collateral changes.

--- a/plugins/governance/marketplace/skills/agent-skills-best-practices/references/trigger-descriptions.md
+++ b/plugins/governance/marketplace/skills/agent-skills-best-practices/references/trigger-descriptions.md
@@ -1,0 +1,15 @@
+# Trigger Descriptions
+
+Treat the frontmatter description as the discovery contract. State what the skill contributes and name concrete user intents, artifacts, or decisions that make it relevant.
+
+```yaml
+# BAD: the description does not give the agent a usable trigger.
+description: Helps with agent skills.
+```
+
+```yaml
+# GOOD: the description names the capability and concrete authoring decisions.
+description: Opinionated PostgreSQL query and schema-design conventions. Use when designing tables, reviewing indexes, diagnosing query plans, changing connection management, or troubleshooting database performance.
+```
+
+Do not repeat trigger lists in a `When to Apply` section. The body loads only after discovery has already happened. Use the opening body prose to explain the governing model instead.

--- a/plugins/governance/marketplace/skills/plugin-best-practices/LICENSE.txt
+++ b/plugins/governance/marketplace/skills/plugin-best-practices/LICENSE.txt
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/plugins/governance/marketplace/skills/plugin-best-practices/SKILL.md
+++ b/plugins/governance/marketplace/skills/plugin-best-practices/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: plugin-best-practices
+description: Opinionated conventions for designing focused agent-skill plugins as encapsulated, installable capabilities. Use when defining a plugin boundary, deciding which skills are public entry points, hiding shared implementation skills, splitting broad plugins, designing plugin structure, minimizing client manifests, or removing auxiliary package documentation.
+license: MPL-2.0
+metadata:
+  author: 'Basti Ortiz <ortiz@bastidood.dev>'
+  source: 'https://github.com/BastiDood/skills'
+---
+
+# Plugin Best Practices
+
+Prefer fine-grained plugins that package one coherent installable capability or body of guidance. Consumers install the plugin as a unit instead of assembling cooperating skills or accepting unrelated functionality.
+
+Treat a plugin as an encapsulation boundary. Like a class in object-oriented programming, it exposes a deliberate public interface while hiding implementation details that consumers do not need to understand or invoke.
+
+A plugin can expose one public skill or several independently useful public skills. Those entry points own consumer-facing outcomes while private skills support them without exposing the internal call graph.
+
+## References
+
+Read as many linked references as are relevant to the plugin design task.
+
+- When translating the public boundary into directories and invocation visibility, [structure the plugin around public outcomes and private implementation skills](./references/plugin-structure.md).
+- When defining plugin metadata or package contents, keep [manifests and packaged files minimal](./references/plugin-manifests.md).

--- a/plugins/governance/marketplace/skills/plugin-best-practices/agents/openai.yaml
+++ b/plugins/governance/marketplace/skills/plugin-best-practices/agents/openai.yaml
@@ -1,0 +1,2 @@
+interface:
+  display_name: 'Plugin Best Practices'

--- a/plugins/governance/marketplace/skills/plugin-best-practices/references/plugin-manifests.md
+++ b/plugins/governance/marketplace/skills/plugin-best-practices/references/plugin-manifests.md
@@ -1,0 +1,5 @@
+# Plugin Manifests
+
+Keep every client manifest minimal. Declare only metadata that current discovery, presentation, compatibility, or dependency behavior consumes. Do not duplicate manifests for clients that can consume an existing canonical format.
+
+Do not add a plugin-local `README.md`, quick reference, installation guide, changelog, or other auxiliary documentation. The skills and required package metadata are the product.

--- a/plugins/governance/marketplace/skills/plugin-best-practices/references/plugin-structure.md
+++ b/plugins/governance/marketplace/skills/plugin-best-practices/references/plugin-structure.md
@@ -1,0 +1,26 @@
+# Plugin Structure
+
+Expose one public skill or several independently useful public skills. Shared collection, normalization, validation, rendering, and other implementation capabilities remain private skills with `user-invocable: false`.
+
+Public skills own consumer-facing outcomes. Private skills own reusable implementation details. A public skill coordinates private capabilities without requiring consumers to understand or invoke the internal stages.
+
+Do not expose a private stage merely because it is implemented as a skill. Promote it only when consumers can request it as a coherent capability of its own.
+
+Keep skill directories as flat siblings under the plugin's skill root. Visibility and responsibility establish the boundary; directory depth does not.
+
+```text
+# BAD: consumers must understand and invoke implementation stages.
+skills/
+├── collect-email-context/
+├── classify-email-priority/
+├── write-email-digest/
+└── render-email-digest/
+
+# GOOD: the plugin exposes its consumer capability and hides shared details.
+skills/
+├── compile-morning-emails/  # Public entry point
+├── collect-email-context/   # user-invocable: false
+├── classify-email-priority/ # user-invocable: false
+├── write-email-digest/      # user-invocable: false
+└── render-email-digest/     # user-invocable: false
+```


### PR DESCRIPTION
This PR adds a brand new marketplace governance skill in `governance/marketplace/`. This is effectively the "skill checker" because it contains all of the conventions that I enforce in [my own personal marketplace](https://github.com/BastiDood/skills).